### PR TITLE
(fix): Fix casing of forwarderARN references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ class CdkStack extends cdk.Stack {
       nodeLayerVersion: <LAYER_VERSION>,
       pythonLayerVersion: <LAYER_VERSION>,
       addLayers: <BOOLEAN>,
-      forwarderArn: "<FORWARDER_ARN>",
+      forwarderARN: "<FORWARDER_ARN>",
       flushMetricsToLogs: <BOOLEAN>,
       site: "<SITE>",
       apiKey: "{Datadog_API_Key}",
@@ -58,7 +58,7 @@ To further configure your Datadog construct, use the following custom parameters
 | `addLayers`          | Whether to add the Lambda Layers or expect the user to bring their own. Defaults to true. When true, the Lambda Library version variables are also required. When false, you must include the Datadog Lambda library in your functions' deployment packages.         |
 | `pythonLayerVersion` | Version of the Python Lambda layer to install, such as 21. Required if you are deploying at least one Lambda function written in Python and `addLayers` is true. Find the latest version number from [https://github.com/DataDog/datadog-lambda-python/releases][5]. |
 | `nodeLayerVersion`   | Version of the Node.js Lambda layer to install, such as 29. Required if you are deploying at least one Lambda function written in Node.js and `addLayers` is true. Find the latest version number from [https://github.com/DataDog/datadog-lambda-js/releases][6].   |
-| `forwarderArn`         | When set, the plugin will automatically subscribe the functions' log groups to the Datadog Forwarder.  |
+| `forwarderARN`         | When set, the plugin will automatically subscribe the functions' log groups to the Datadog Forwarder.  |
 | `flushMetricsToLogs` | Send custom metrics using Cloudwatch logs with the Datadog Forwarder Lambda function (recommended). Defaults to `true`. If you disable this parameter, it's required to set the parameters `site` and `apiKey` (or `apiKMSKey` if encrypted). |
 | `site`               | Set which Datadog site to send data, only needed when flushMetricsToLogs is `false`. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. |
 | `apiKey`             | Datadog API Key, only needed when `flushMetricsToLogs` is `false`. For more information about getting a Datadog API key, see the [API key documentation][8]. |


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Makes documentation references to `forwarderARN` consistent with the TS interface in the code.

### Motivation

Lazy people like me who copy / paste options from the README see a TS error related to `forwarderARN` due this casing difference.

### Testing Guidelines

N/A

### Additional Notes

N/A

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
