### PR TITLE
Duplicate Constructs Bug 🐛

### DIFF
--- a/lib/forwarder.ts
+++ b/lib/forwarder.ts
@@ -13,6 +13,9 @@ import * as crypto from "crypto";
 import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";
 const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Function[], forwarderARN: string) {
+  if (scope.node.tryFindChild("forwarder")) {
+    return;
+  }
   const forwarder = lambda.Function.fromFunctionArn(scope, "forwarder", forwarderARN);
   const forwarderDestination = new LambdaDestination(forwarder);
   lambdaFunctions.forEach((lam) => {

--- a/lib/forwarder.ts
+++ b/lib/forwarder.ts
@@ -13,7 +13,7 @@ import * as crypto from "crypto";
 import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";
 const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 
-function generateForwaderConstrucId(forwarderArn: string) {
+function generateForwaderConstructId(forwarderArn: string) {
   return "forwarder" + crypto.createHash("sha256").update(forwarderArn).digest("hex");
 }
 function generateSubscriptionFilterName(functionArn: string, forwarderArn: string) {
@@ -31,12 +31,12 @@ function generateSubscriptionFilterName(functionArn: string, forwarderArn: strin
 }
 
 export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Function[], forwarderArn: string) {
-  const forwarderConstructID = generateForwaderConstrucId(forwarderArn);
+  const forwarderConstructId = generateForwaderConstructId(forwarderArn);
   let forwarder;
-  if (scope.node.tryFindChild(forwarderConstructID)) {
-    forwarder = scope.node.tryFindChild(forwarderConstructID) as lambda.IFunction;
+  if (scope.node.tryFindChild(forwarderConstructId)) {
+    forwarder = scope.node.tryFindChild(forwarderConstructId) as lambda.IFunction;
   } else {
-    forwarder = lambda.Function.fromFunctionArn(scope, forwarderConstructID, forwarderArn);
+    forwarder = lambda.Function.fromFunctionArn(scope, forwarderConstructId, forwarderArn);
   }
   const forwarderDestination = new LambdaDestination(forwarder);
   lambdaFunctions.forEach((lam) => {

--- a/lib/layer.ts
+++ b/lib/layer.ts
@@ -56,14 +56,14 @@ export function applyLayers(
       return;
     }
 
-    let layerARN;
+    let layerArn;
 
     if (lambdaRuntimeType === RuntimeType.PYTHON) {
       if (pythonLayerVersion === undefined) {
         errors.push(getMissingLayerVersionErrorMsg(lam.node.id, "Python", "python"));
         return;
       }
-      layerARN = getLayerARN(region, pythonLayerVersion, runtime);
+      layerArn = getLayerARN(region, pythonLayerVersion, runtime);
     }
 
     if (lambdaRuntimeType === RuntimeType.NODE) {
@@ -71,14 +71,14 @@ export function applyLayers(
         errors.push(getMissingLayerVersionErrorMsg(lam.node.id, "Node.js", "node"));
         return;
       }
-      layerARN = getLayerARN(region, nodeLayerVersion, runtime);
+      layerArn = getLayerARN(region, nodeLayerVersion, runtime);
     }
-    if (layerARN !== undefined) {
-      let layer = layers.get(layerARN);
+    if (layerArn !== undefined) {
+      let layer = layers.get(layerArn);
       if (layer === undefined) {
         const layerId = generateLayerId(lam.functionArn, runtime);
-        layer = lambda.LayerVersion.fromLayerVersionArn(scope, layerId, layerARN);
-        layers.set(layerARN, layer); // could have token in key string
+        layer = lambda.LayerVersion.fromLayerVersionArn(scope, layerId, layerArn);
+        layers.set(layerArn, layer); // could have token in key string
       }
       // TODO: check if layer extracted generated error or is undefined
       lam.addLayers(layer);

--- a/lib/layer.ts
+++ b/lib/layer.ts
@@ -76,8 +76,8 @@ export function applyLayers(
     if (layerARN !== undefined) {
       let layer = layers.get(layerARN);
       if (layer === undefined) {
-        const layerID = generateLayerID(lam.functionArn, runtime);
-        layer = lambda.LayerVersion.fromLayerVersionArn(scope, layerID, layerARN);
+        const layerId = generateLayerId(lam.functionArn, runtime);
+        layer = lambda.LayerVersion.fromLayerVersionArn(scope, layerId, layerARN);
         layers.set(layerARN, layer); // could have token in key string
       }
       // TODO: check if layer extracted generated error or is undefined
@@ -106,7 +106,7 @@ export function getMissingLayerVersionErrorMsg(functionKey: string, formalRuntim
   );
 }
 
-function generateLayerID(lambdaFunctionArn: string, runtime: string) {
+function generateLayerId(lambdaFunctionArn: string, runtime: string) {
   const layerValue: string = crypto.createHash("sha256").update(lambdaFunctionArn).digest("hex");
   return layerPrefix + "-" + runtime + "-" + layerValue;
 }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -18,49 +18,7 @@ function createSubscriptionFilterName(lambdaFunctionArn:string,forwarderArn:stri
     return subscriptionFilterName;
 }
 describe("addForwarder", () => {
-  it("Subscribes two seperate forwarder's to the same lambda via seperate addLambdaFunctions function calls",() => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "stack", {
-      env: {
-        region: "sa-east-1",
-      },
-    });
-    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
-    const datadogCdk = new Datadog(stack, "Datadog", {
-      nodeLayerVersion: 40,
-      pythonLayerVersion: 28,
-      addLayers: true,
-      forwarderARN: "forwarder-arn",
-      enableDDTracing: true,
-      flushMetricsToLogs: true,
-      site: "datadoghq.com",
-    });
-    datadogCdk.addLambdaFunctions([nodeLambda]);
-    const datadogCdk2 = new Datadog(stack, "Datadog2", {
-      nodeLayerVersion: 40,
-      pythonLayerVersion: 28,
-      addLayers: true,
-      forwarderARN: "forwarder-arn2",
-      enableDDTracing: true,
-      flushMetricsToLogs: true,
-      site: "datadoghq.com",
-    });
-    datadogCdk2.addLambdaFunctions([nodeLambda]);
-    expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
-      FilterPattern: "",
-    });
-    expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn2",
-      FilterPattern: "",
-    });
-  });
-
-  it("Subscribes the same forwarder to two different lambda functions via seperate addLambdaFunctions function calls",() => {
+  it("Subscribes the same forwarder to two different lambda functions via separate addLambdaFunctions function calls",() => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "stack", {
       env: {
@@ -149,7 +107,7 @@ describe("addForwarder", () => {
     expect(throwsError).toBe(true);
   });
 
-  it("Subscribes two different forwarders to two different lambda functions via seperate addForwarder function calls",() => {
+  it("Subscribes two different forwarders to two different lambda functions via separate addForwarder function calls",() => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "stack", {
       env: {


### PR DESCRIPTION
### Duplicate ‘forwarder’ constructs bug 
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->
### What does this PR do?
This PR changes the logic for the creation of the `forwarder`, `subscriptionFilter`, and `layer` constructs in an attempt to never create duplicate constructs in the same cdk construct tree while also methodically creating new constructs only when necessary.

A customer ran into this error `There is already a Construct with name 'forwarder' in ...`. After doing some research I was able to reproduce the error by creating a unit test that created a mock aws-cdk app, stack, and constructs related to the Datadog-cdk-construct library. This unit test intentionally called the `addForwarder` function twice. I am not sure if this is exactly how the customer encountered this problem but I believe my solution should prevent it from happening again.
Before both `addForwarder` calls our construct tree looked like this:  
app/
|─ stack/
│  ├─ AssetParameters
│  ├─ NodeHandler

After 1 `addForwarder` call the construct tree looked like this (as you can see the forwarder construct was successfully added):
app/
|─ stack/
│  ├─ AssetParameters
│  ├─ forwarder
│  ├─ LogRetention
│  ├─ NodeHandler

Now the problem occurs when the `addForwarder` function is called for the second time. Since the forwarder construct already exists in the construct tree the deployment will fail here because there cannot be duplicate constructs in the same cdk construct tree. As illustrated with the picture below, the 2nd call is trying to place another `forwarder` construct in the tree.
app/
|─ stack/
│  ├─ AssetParameters
│  ├─ forwarder
│  ├─ forwarder //this causes the error
│  ├─ LogRetention
│  ├─ NodeHandler

### Testing Guidelines
I created a unit tests in the index.spec.ts file to test my changes while also building and packing my local version of the dd-cdk-constructs and testing the unit tests manually in my [lambda-cdk-constructs-demo project](https://github.com/DataDog/cloud-integrations-lambdas/tree/master/lambda-cdk-constructs-demo).

### Additional Notes
This is the error I produced compared to the error on the [ticket](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205?selectedIssue=SLS-973) 
![addForwarder  does not create duplicate forwarder constructs](https://user-images.githubusercontent.com/49878080/108390130-32d13700-71c5-11eb-926c-eb9d6f753df2.png)

I learned about the construct tree here https://docs.aws.amazon.com/cdk/latest/guide/constructs.html, also this picture helped a lot.
![Construct](https://user-images.githubusercontent.com/49878080/108390254-54cab980-71c5-11eb-9bc2-c9bf4c1bf8a3.png)
https://d2908q01vomqb2.cloudfront.net/da4b9237bacccdf19c0760cab7aec4a8359010b0/2018/12/17/appstack.png

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)

