### PR TITLE
Ensure log group subscription filter resource has stable id

### DIFF
--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -12,7 +12,7 @@ import { FilterPattern } from "@aws-cdk/aws-logs";
 import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";
 import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
-const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
+export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 
 function generateForwaderConstructId(forwarderArn: string) {
   log.debug("Generating construct Id for Datadog Lambda Forwarder");

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -18,10 +18,10 @@ function generateForwaderConstructId(forwarderArn: string) {
   log.debug("Generating construct Id for Datadog Lambda Forwarder");
   return "forwarder" + crypto.createHash("sha256").update(forwarderArn).digest("hex");
 }
-function generateSubscriptionFilterName(functionArn: string, forwarderArn: string) {
+function generateSubscriptionFilterName(functionUniqueId: string, forwarderArn: string) {
   const subscriptionFilterValue: string = crypto
     .createHash("sha256")
-    .update(functionArn)
+    .update(functionUniqueId)
     .update(forwarderArn)
     .digest("hex");
   const subscriptionFilterValueLength = subscriptionFilterValue.length;
@@ -42,7 +42,7 @@ export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Funct
   }
   const forwarderDestination = new LambdaDestination(forwarder);
   lambdaFunctions.forEach((lam) => {
-    const subscriptionFilterName = generateSubscriptionFilterName(lam.functionArn, forwarderArn);
+    const subscriptionFilterName = generateSubscriptionFilterName(cdk.Names.uniqueId(lam), forwarderArn);
     log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);
     lam.logGroup.addSubscriptionFilter(subscriptionFilterName, {
       destination: forwarderDestination,

--- a/test/forwarder.spec.ts
+++ b/test/forwarder.spec.ts
@@ -44,12 +44,11 @@ describe("Forwarder", () => {
 
     addForwarder(stack, [nodeLambda, pythonLambda], "forwarder-arn");
 
-    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
-    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
-
-    expect(nodeLambdaSubscriptionFilter).toBeDefined();
-    expect(pythonLambdaSubscriptionFilter).toBeDefined();
-    expect(nodeLambdaSubscriptionFilter.destinationArn).toEqual(pythonLambdaSubscriptionFilter.destinationArn);
+    const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
+    const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
+    expect(nodeLambdaSubscriptionFilters).toHaveLength(1);
+    expect(pythonLambdaSubscriptionFilters).toHaveLength(1);
+    expect(nodeLambdaSubscriptionFilters[0].destinationArn).toEqual(pythonLambdaSubscriptionFilters[0].destinationArn);
   });
 
   it("Subscribes two different forwarders to two different lambda functions via separate addForwarder function calls", () => {
@@ -73,11 +72,13 @@ describe("Forwarder", () => {
     addForwarder(stack, [nodeLambda], "forwarder-arn");
     addForwarder(stack, [pythonLambda], "forwarder-arn-2");
 
-    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
-    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
-    expect(nodeLambdaSubscriptionFilter).toBeDefined();
-    expect(pythonLambdaSubscriptionFilter).toBeDefined();
-    expect(nodeLambdaSubscriptionFilter.destinationArn).not.toEqual(pythonLambdaSubscriptionFilter.destinationArn);
+    const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
+    const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
+    expect(nodeLambdaSubscriptionFilters).toHaveLength(1);
+    expect(pythonLambdaSubscriptionFilters).toHaveLength(1);
+    expect(nodeLambdaSubscriptionFilters[0].destinationArn).not.toEqual(
+      pythonLambdaSubscriptionFilters[0].destinationArn,
+    );
   });
 
   it("Produces stable log subscription resource ids", () => {

--- a/test/forwarder.spec.ts
+++ b/test/forwarder.spec.ts
@@ -2,6 +2,7 @@ import * as lambda from "@aws-cdk/aws-lambda";
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
 import { addForwarder } from "../src/forwarder";
+import { findDatadogSubscriptionFilters } from "./test-utils";
 
 describe("Forwarder", () => {
   it("applies the subscription filter correctly", () => {
@@ -21,5 +22,91 @@ describe("Forwarder", () => {
       DestinationArn: "forwarder-arn",
       FilterPattern: "",
     });
+  });
+
+  it("Subscribes the same forwarder to two different lambda functions via one addForwarder function call", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+    const pythonLambda = new lambda.Function(stack, "PythonHandler", {
+      runtime: lambda.Runtime.PYTHON_3_7,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+
+    addForwarder(stack, [nodeLambda, pythonLambda], "forwarder-arn");
+
+    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
+    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
+
+    expect(nodeLambdaSubscriptionFilter).toBeDefined();
+    expect(pythonLambdaSubscriptionFilter).toBeDefined();
+    expect(nodeLambdaSubscriptionFilter.destinationArn).toEqual(pythonLambdaSubscriptionFilter.destinationArn);
+  });
+
+  it("Subscribes two different forwarders to two different lambda functions via separate addForwarder function calls", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+    const pythonLambda = new lambda.Function(stack, "PythonHandler", {
+      runtime: lambda.Runtime.PYTHON_3_7,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+
+    addForwarder(stack, [nodeLambda], "forwarder-arn");
+    addForwarder(stack, [pythonLambda], "forwarder-arn-2");
+
+    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
+    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
+    expect(nodeLambdaSubscriptionFilter).toBeDefined();
+    expect(pythonLambdaSubscriptionFilter).toBeDefined();
+    expect(nodeLambdaSubscriptionFilter.destinationArn).not.toEqual(pythonLambdaSubscriptionFilter.destinationArn);
+  });
+
+  it("Produces stable log subscription resource ids", () => {
+    const createStack = (functionId: string) => {
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "stack", {
+        env: {
+          region: "us-gov-east-1",
+        },
+      });
+      const pythonLambda = new lambda.Function(stack, functionId, {
+        runtime: lambda.Runtime.PYTHON_3_7,
+        code: lambda.Code.fromAsset("test"),
+        handler: "hello.handler",
+      });
+      addForwarder(stack, [pythonLambda], "forwarder-arn");
+
+      return stack;
+    };
+
+    const initialStack = createStack("PythonHandler");
+    const identicalStack = createStack("PythonHandler");
+    const differentStack = createStack("OtherHandler");
+
+    const [initialStackSubscription] = findDatadogSubscriptionFilters(initialStack);
+    const [identicalStackSubscription] = findDatadogSubscriptionFilters(identicalStack);
+    const [differentStackSubscription] = findDatadogSubscriptionFilters(differentStack);
+
+    expect(initialStackSubscription.id).toEqual(identicalStackSubscription.id);
+    expect(initialStackSubscription.id).not.toEqual(differentStackSubscription.id);
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -187,7 +187,7 @@ describe("addForwarder", () => {
     const [differentStackSubscription] = findDatadogSubscriptionFilters(differentStack);
 
     expect(initialStackSubscription.id).toEqual(identicalStackSubscription.id);
-    expect(initialStackSubscription).not.toEqual(differentStackSubscription.id);
+    expect(initialStackSubscription.id).not.toEqual(differentStackSubscription.id);
   });
 });
 describe("applyLayers", () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -35,11 +35,11 @@ describe("addLambdaFunctions", () => {
     datadogCdk.addLambdaFunctions([nodeLambda]);
     datadogCdk.addLambdaFunctions([pythonLambda]);
 
-    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
-    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
-    expect(nodeLambdaSubscriptionFilter).toBeDefined();
-    expect(pythonLambdaSubscriptionFilter).toBeDefined();
-    expect(nodeLambdaSubscriptionFilter.destinationArn).toEqual(pythonLambdaSubscriptionFilter.destinationArn);
+    const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
+    const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
+    expect(nodeLambdaSubscriptionFilters).toHaveLength(1);
+    expect(pythonLambdaSubscriptionFilters).toHaveLength(1);
+    expect(nodeLambdaSubscriptionFilters[0].destinationArn).toEqual(pythonLambdaSubscriptionFilters[0].destinationArn);
   });
 
   it("Throws an error when a customer redundantly calls the addLambdaFunctions function on the same lambda function(s) and forwarder", () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,30 +1,11 @@
 import * as lambda from "@aws-cdk/aws-lambda";
-import { CfnSubscriptionFilter } from "@aws-cdk/aws-logs";
-
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
-import { addForwarder } from "../src/forwarder";
 import { Datadog, logForwardingEnvVar, enableDDTracingEnvVar, injectLogContextEnvVar } from "../src/index";
 import { JS_HANDLER_WITH_LAYERS, DD_HANDLER_ENV_VAR, PYTHON_HANDLER } from "../src/redirect";
-const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
+import { findDatadogSubscriptionFilters } from "./test-utils";
 
-function findDatadogSubscriptionFilters(stack: cdk.Stack) {
-  return stack.node
-    .findAll()
-    .filter((construct) => construct.node.id.startsWith(SUBSCRIPTION_FILTER_PREFIX))
-    .map((construct) => {
-      const cfnSubscriptionFilter = construct.node.children.find(
-        (child) => child instanceof CfnSubscriptionFilter,
-      ) as CfnSubscriptionFilter;
-
-      return {
-        id: construct.node.id,
-        destinationArn: cfnSubscriptionFilter.destinationArn,
-      };
-    });
-}
-
-describe("addForwarder", () => {
+describe("addLambdaFunctions", () => {
   it("Subscribes the same forwarder to two different lambda functions via separate addLambdaFunctions function calls", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "stack", {
@@ -54,35 +35,11 @@ describe("addForwarder", () => {
     datadogCdk.addLambdaFunctions([nodeLambda]);
     datadogCdk.addLambdaFunctions([pythonLambda]);
 
-    const subscriptionFilters = findDatadogSubscriptionFilters(stack);
-    expect(nodeLambda.logGroup.node.tryFindChild(subscriptionFilters[0].id)).not.toBeUndefined();
-    expect(pythonLambda.logGroup.node.tryFindChild(subscriptionFilters[1].id)).not.toBeUndefined();
-    expect(subscriptionFilters[0].destinationArn).toEqual(subscriptionFilters[1].destinationArn);
-  });
-
-  it("Subscribes the same forwarder to two different lambda functions via one addForwarder function call", () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "stack", {
-      env: {
-        region: "sa-east-1",
-      },
-    });
-    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
-    const pythonLambda = new lambda.Function(stack, "PythonHandler", {
-      runtime: lambda.Runtime.PYTHON_3_7,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
-    addForwarder(stack, [nodeLambda, pythonLambda], "forwarder-arn");
-
-    const subscriptionFilters = findDatadogSubscriptionFilters(stack);
-    expect(nodeLambda.logGroup.node.tryFindChild(subscriptionFilters[0].id)).not.toBeUndefined();
-    expect(pythonLambda.logGroup.node.tryFindChild(subscriptionFilters[1].id)).not.toBeUndefined();
-    expect(subscriptionFilters[0].destinationArn).toEqual(subscriptionFilters[1].destinationArn);
+    const [nodeLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(nodeLambda);
+    const [pythonLambdaSubscriptionFilter] = findDatadogSubscriptionFilters(pythonLambda);
+    expect(nodeLambdaSubscriptionFilter).toBeDefined();
+    expect(pythonLambdaSubscriptionFilter).toBeDefined();
+    expect(nodeLambdaSubscriptionFilter.destinationArn).toEqual(pythonLambdaSubscriptionFilter.destinationArn);
   });
 
   it("Throws an error when a customer redundantly calls the addLambdaFunctions function on the same lambda function(s) and forwarder", () => {
@@ -115,81 +72,8 @@ describe("addForwarder", () => {
     }
     expect(throwsError).toBe(true);
   });
-
-  it("Subscribes two different forwarders to two different lambda functions via separate addForwarder function calls", () => {
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "stack", {
-      env: {
-        region: "sa-east-1",
-      },
-    });
-    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
-    const pythonLambda = new lambda.Function(stack, "PythonHandler", {
-      runtime: lambda.Runtime.PYTHON_3_7,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
-    const datadogCdk = new Datadog(stack, "Datadog", {
-      nodeLayerVersion: 20,
-      pythonLayerVersion: 28,
-      addLayers: true,
-      forwarderArn: "forwarder-arn",
-      enableDatadogTracing: true,
-      flushMetricsToLogs: true,
-      site: "datadoghq.com",
-    });
-    const datadogCdk2 = new Datadog(stack, "Datadog2", {
-      nodeLayerVersion: 20,
-      pythonLayerVersion: 28,
-      addLayers: true,
-      forwarderArn: "forwarder-arn2",
-      enableDatadogTracing: true,
-      flushMetricsToLogs: true,
-      site: "datadoghq.com",
-    });
-    datadogCdk.addLambdaFunctions([nodeLambda]);
-    datadogCdk2.addLambdaFunctions([pythonLambda]);
-
-    const subscriptionFilters = findDatadogSubscriptionFilters(stack);
-    expect(nodeLambda.logGroup.node.tryFindChild(subscriptionFilters[0].id)).not.toBeUndefined();
-    expect(pythonLambda.logGroup.node.tryFindChild(subscriptionFilters[1].id)).not.toBeUndefined();
-    expect(subscriptionFilters[0].destinationArn).not.toEqual(subscriptionFilters[1].destinationArn);
-  });
-
-  it("Produces stable log subscription resource ids", () => {
-    const createStack = (functionId: string) => {
-      const app = new cdk.App();
-      const stack = new cdk.Stack(app, "stack", {
-        env: {
-          region: "us-gov-east-1",
-        },
-      });
-      const pythonLambda = new lambda.Function(stack, functionId, {
-        runtime: lambda.Runtime.PYTHON_3_7,
-        code: lambda.Code.fromAsset("test"),
-        handler: "hello.handler",
-      });
-      addForwarder(stack, [pythonLambda], "forwarder-arn");
-
-      return stack;
-    };
-
-    const initialStack = createStack("PythonHandler");
-    const identicalStack = createStack("PythonHandler");
-    const differentStack = createStack("OtherHandler");
-
-    const [initialStackSubscription] = findDatadogSubscriptionFilters(initialStack);
-    const [identicalStackSubscription] = findDatadogSubscriptionFilters(identicalStack);
-    const [differentStackSubscription] = findDatadogSubscriptionFilters(differentStack);
-
-    expect(initialStackSubscription.id).toEqual(identicalStackSubscription.id);
-    expect(initialStackSubscription.id).not.toEqual(differentStackSubscription.id);
-  });
 });
+
 describe("applyLayers", () => {
   it("if addLayers is not given, layer is added", () => {
     const app = new cdk.App();

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,0 +1,21 @@
+import { CfnSubscriptionFilter } from "@aws-cdk/aws-logs";
+import * as cdk from "@aws-cdk/core";
+import { SUBSCRIPTION_FILTER_PREFIX } from "../src/forwarder";
+
+export const findDatadogSubscriptionFilters = (baseConstruct: cdk.Construct) => {
+  return baseConstruct.node
+    .findAll()
+    .filter((construct) => construct.node.id.startsWith(SUBSCRIPTION_FILTER_PREFIX))
+    .map((construct) => {
+      const cfnSubscriptionFilters = construct.node.children.filter(
+        (child) => child instanceof CfnSubscriptionFilter,
+      ) as CfnSubscriptionFilter[];
+
+      expect(cfnSubscriptionFilters).toHaveLength(1);
+
+      return {
+        id: construct.node.id,
+        destinationArn: cfnSubscriptionFilters[0].destinationArn,
+      };
+    });
+};

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,3 +1,4 @@
+import { Function } from "@aws-cdk/aws-lambda";
 import { CfnSubscriptionFilter } from "@aws-cdk/aws-logs";
 import * as cdk from "@aws-cdk/core";
 import { SUBSCRIPTION_FILTER_PREFIX } from "../src/forwarder";
@@ -11,7 +12,9 @@ export const findDatadogSubscriptionFilters = (baseConstruct: cdk.Construct) => 
         (child) => child instanceof CfnSubscriptionFilter,
       ) as CfnSubscriptionFilter[];
 
-      expect(cfnSubscriptionFilters).toHaveLength(1);
+      if (baseConstruct instanceof Function) {
+        expect(cfnSubscriptionFilters).toHaveLength(1);
+      }
 
       return {
         id: construct.node.id,

--- a/test/test-utils.ts
+++ b/test/test-utils.ts
@@ -1,4 +1,3 @@
-import { Function } from "@aws-cdk/aws-lambda";
 import { CfnSubscriptionFilter } from "@aws-cdk/aws-logs";
 import * as cdk from "@aws-cdk/core";
 import { SUBSCRIPTION_FILTER_PREFIX } from "../src/forwarder";
@@ -12,13 +11,12 @@ export const findDatadogSubscriptionFilters = (baseConstruct: cdk.Construct) => 
         (child) => child instanceof CfnSubscriptionFilter,
       ) as CfnSubscriptionFilter[];
 
-      if (baseConstruct instanceof Function) {
-        expect(cfnSubscriptionFilters).toHaveLength(1);
-      }
-
-      return {
-        id: construct.node.id,
-        destinationArn: cfnSubscriptionFilters[0].destinationArn,
-      };
-    });
+      return cfnSubscriptionFilters.map((cfnSubcriptionFilter) => {
+        return {
+          id: construct.node.id,
+          destinationArn: cfnSubcriptionFilter.destinationArn,
+        };
+      });
+    })
+    .reduce((acc, subscriptionFilters) => acc.concat(subscriptionFilters), []);
 };


### PR DESCRIPTION
### What does this PR do?

This PR calls ensures the log filter subscription resource id does not change on subsequent cdk deploys.

### Motivation

Every time I deploy my app utilizing datadog-cdk-constructs, I see that the log subscription filters are deleted and re-added by CloudFormation. This due to references being passed in as the functionArn to generateForwaderConstructId, and the reference ID numbers are not stable across synth operations. See below for back-to-back cdk diff operations:

![CleanShot 2021-04-15 at 20 59 10](https://user-images.githubusercontent.com/1062734/114959036-3c2bf800-9e32-11eb-96ae-611f41e9487c.png)


### Testing Guidelines

An additional unit test was added that shows two identical -- but independent -- stacks produce the same name of the subscription filter, but a third stack with a differently named resource does not.

### Additional Notes

The implementation of the existing unit tests inlined the actual id generation algorithm, so I modified these tests to instead introspect the CDK data structures to confirm everything is working.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (test refactoring)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
