### PR TITLE
Fix Policy Length error when using a large number of lambda functions

### DIFF
--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -9,10 +9,10 @@
 import * as crypto from "crypto";
 import * as lambda from "@aws-cdk/aws-lambda";
 import { FilterPattern } from "@aws-cdk/aws-logs";
-// Change back to 'import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";'
-// once https://github.com/aws/aws-cdk/pull/14222 is merged and released.
 import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
+// Change back to 'import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";'
+// once https://github.com/aws/aws-cdk/pull/14222 is merged and released.
 import { LambdaDestination } from "./lambdaDestination";
 const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -9,7 +9,9 @@
 import * as crypto from "crypto";
 import * as lambda from "@aws-cdk/aws-lambda";
 import { FilterPattern } from "@aws-cdk/aws-logs";
-import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";
+// Change back to 'import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";'
+// once https://github.com/aws/aws-cdk/pull/14222 is merged and released.
+import { LambdaDestination } from "./lambdaDestination";
 import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
 const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
@@ -40,7 +42,7 @@ export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Funct
   } else {
     forwarder = lambda.Function.fromFunctionArn(scope, forwarderConstructId, forwarderArn);
   }
-  const forwarderDestination = new LambdaDestination(forwarder);
+  const forwarderDestination = new LambdaDestination(forwarder, false);
   lambdaFunctions.forEach((lam) => {
     const subscriptionFilterName = generateSubscriptionFilterName(lam.functionArn, forwarderArn);
     log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -11,9 +11,9 @@ import * as lambda from "@aws-cdk/aws-lambda";
 import { FilterPattern } from "@aws-cdk/aws-logs";
 // Change back to 'import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";'
 // once https://github.com/aws/aws-cdk/pull/14222 is merged and released.
-import { LambdaDestination } from "./lambdaDestination";
 import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
+import { LambdaDestination } from "./lambdaDestination";
 const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 
 function generateForwaderConstructId(forwarderArn: string) {
@@ -42,7 +42,7 @@ export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Funct
   } else {
     forwarder = lambda.Function.fromFunctionArn(scope, forwarderConstructId, forwarderArn);
   }
-  const forwarderDestination = new LambdaDestination(forwarder, false);
+  const forwarderDestination = new LambdaDestination(forwarder);
   lambdaFunctions.forEach((lam) => {
     const subscriptionFilterName = generateSubscriptionFilterName(lam.functionArn, forwarderArn);
     log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);

--- a/src/lambdaDestination.ts
+++ b/src/lambdaDestination.ts
@@ -15,4 +15,3 @@ export class LambdaDestination implements logs.ILogSubscriptionDestination {
     return { arn: this.fn.functionArn };
   }
 }
-

--- a/src/lambdaDestination.ts
+++ b/src/lambdaDestination.ts
@@ -1,17 +1,14 @@
 import * as lambda from "@aws-cdk/aws-lambda";
 import * as logs from "@aws-cdk/aws-logs";
-import { Construct } from "@aws-cdk/core";
 
 /**
- * Use a Lamda Function as the destination for a log subscription.
+ * Use a Lambda Function as the destination for a log subscription.
  * Using this class temporarily until https://github.com/aws/aws-cdk/pull/14222 is merged and released.
  */
 export class LambdaDestination implements logs.ILogSubscriptionDestination {
   constructor(private readonly fn: lambda.IFunction) {}
 
-  public bind(scope: Construct, logGroup: logs.ILogGroup): logs.LogSubscriptionDestinationConfig {
-    scope.toString;
-    logGroup.logGroupName; //get around not using the params
+  public bind(): logs.LogSubscriptionDestinationConfig {
     return { arn: this.fn.functionArn };
   }
 }

--- a/src/lambdaDestination.ts
+++ b/src/lambdaDestination.ts
@@ -1,0 +1,27 @@
+import * as iam from "@aws-cdk/aws-iam";
+import * as lambda from "@aws-cdk/aws-lambda";
+import * as logs from "@aws-cdk/aws-logs";
+import { Construct } from "@aws-cdk/core";
+
+/**
+ * Use a Lamda Function as the destination for a log subscription.
+ * Using this class temporarily until https://github.com/aws/aws-cdk/pull/14222 is merged and released.
+ */
+ export class LambdaDestination implements logs.ILogSubscriptionDestination {
+  constructor(private readonly fn: lambda.IFunction, private readonly addPermissions: boolean=true) {
+  }
+
+  public bind(scope: Construct, logGroup: logs.ILogGroup): logs.LogSubscriptionDestinationConfig {
+    const arn = logGroup.logGroupArn;
+    if (this.addPermissions === true) {
+      this.fn.addPermission('CanInvokeLambda', {
+        principal: new iam.ServicePrincipal('logs.amazonaws.com'),
+        sourceArn: arn,
+        // Using SubScription Filter as scope is okay, since every Subscription Filter has only
+        // one destination.
+        scope,
+      });
+    }
+    return { arn: this.fn.functionArn };
+  }
+}

--- a/src/lambdaDestination.ts
+++ b/src/lambdaDestination.ts
@@ -1,4 +1,3 @@
-import * as iam from "@aws-cdk/aws-iam";
 import * as lambda from "@aws-cdk/aws-lambda";
 import * as logs from "@aws-cdk/aws-logs";
 import { Construct } from "@aws-cdk/core";
@@ -7,21 +6,13 @@ import { Construct } from "@aws-cdk/core";
  * Use a Lamda Function as the destination for a log subscription.
  * Using this class temporarily until https://github.com/aws/aws-cdk/pull/14222 is merged and released.
  */
- export class LambdaDestination implements logs.ILogSubscriptionDestination {
-  constructor(private readonly fn: lambda.IFunction, private readonly addPermissions: boolean=true) {
-  }
+export class LambdaDestination implements logs.ILogSubscriptionDestination {
+  constructor(private readonly fn: lambda.IFunction) {}
 
   public bind(scope: Construct, logGroup: logs.ILogGroup): logs.LogSubscriptionDestinationConfig {
-    const arn = logGroup.logGroupArn;
-    if (this.addPermissions === true) {
-      this.fn.addPermission('CanInvokeLambda', {
-        principal: new iam.ServicePrincipal('logs.amazonaws.com'),
-        sourceArn: arn,
-        // Using SubScription Filter as scope is okay, since every Subscription Filter has only
-        // one destination.
-        scope,
-      });
-    }
+    scope.toString;
+    logGroup.logGroupName; //get around not using the params
     return { arn: this.fn.functionArn };
   }
 }
+


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Fixes: [SLS-1075](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205?selectedIssue=SLS-1075)

Implements `ILogSubscriptionDestination` as `LambdaDestination` but removes the logic of adding Lambda Permissions. While we wait for this aws-cdk [PR](https://github.com/aws/aws-cdk/pull/14222)  to merge I implemented the class locally to fix the policy length problem. The local class can be removed and used in favor with `import { LambdaDestination } from "@aws-cdk/aws-logs-destinations";` once the AWS-CDK PR is merged and released. **Or if we decide this can wait we can simply put [SLS-1075](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205?selectedIssue=SLS-1075) on blocked until AWS-CDK merges and releases the fixes.**
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Customers ran into issues with the policy length exceeding the limit when trying to deploy a large amount of lambda functions with our DD CDK Construct (see [SLES-508](https://datadoghq.atlassian.net/browse/SLES-508)). 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
First I manually created a CDK stack that contained 41 lambda functions (see [SLES-508](https://datadoghq.atlassian.net/browse/SLES-508) to find out why I chose that number). 

Then I attempted to deploy the stack with opting in to add lambda permissions (by using the the current version of [LambdaDestination](https://github.com/aws/aws-cdk/blob/master/packages/@aws-cdk/aws-logs-destinations/lib/lambda.ts#L9)), the deployment failed.

When I opted out of adding the lambda permissions (by using the locally implemented [LambdaDestination](https://github.com/DataDog/datadog-cdk-constructs/blob/b5137d88e3cd777b25287752c7c47bf9b33f583a/src/lambdaDestination.ts#L9)), the deployment succeeded.
<!--- How did you test this pull request? --->

### Additional Notes
We can opt out of adding lambda permissions because the Datadog Forwarder is deployed with a global [permission](https://github.com/DataDog/datadog-serverless-functions/blob/083957182b8475406d443d70391a6f5018102973/aws/logs_monitoring/template.yaml#L554)  to allow any log group to invoke it.
<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
