### PR TITLE
Add `dd_cdk_construct` tag to all lambda functions deployed via the DD CDK Construct

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,9 +42,7 @@
     "coverage"
   ],
   "rules": {
-    "@typescript-eslint/no-require-imports": [
-      "error"
-    ],
+    "@typescript-eslint/no-require-imports": "off",
     "indent": [
       "off"
     ],
@@ -216,6 +214,7 @@
         ]
       }
     ],
+    "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -68,6 +68,8 @@ eslintConfig.addOverride("extends", [
 ]);
 
 eslintConfig.addOverride("rules", {
+  "@typescript-eslint/no-require-imports": "off",
+  "@typescript-eslint/no-var-requires": "off",
   "@typescript-eslint/no-explicit-any": "off",
   "@typescript-eslint/no-empty-interface": "off",
   "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -11,7 +11,7 @@ import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
 import { applyLayers, redirectHandlers, addForwarder, applyEnvVariables, defaultEnvVar } from "./index";
 import { Transport } from "./transport";
-const version = require("../version.json");
+const versionJson = require("../version.json");
 
 export interface DatadogProps {
   readonly pythonLayerVersion?: number;
@@ -96,9 +96,11 @@ export class Datadog extends cdk.Construct {
  * Tags the function(s) with DD Cdk version
  */
 export function addCdkTag(lambdaFunctions: lambda.Function[]) {
-  log.debug(`Adding CDK Version ${version}`);
+  log.debug(`Adding CDK Version ${versionJson.version}`);
   lambdaFunctions.forEach((functionName) => {
-    cdk.Tags.of(functionName).add(TagKeys.Cdk, `v${version}`, { includeResourceTypes: ["AWS::Lambda::Function"] });
+    cdk.Tags.of(functionName).add(TagKeys.Cdk, `v${versionJson.version}`, {
+      includeResourceTypes: ["AWS::Lambda::Function"],
+    });
   });
 }
 

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -11,6 +11,7 @@ import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
 import { applyLayers, redirectHandlers, addForwarder, applyEnvVariables, defaultEnvVar } from "./index";
 import { Transport } from "./transport";
+const version = require("../version.json");
 
 export interface DatadogProps {
   readonly pythonLayerVersion?: number;
@@ -24,6 +25,10 @@ export interface DatadogProps {
   readonly apiKmsKey?: string;
   readonly enableDatadogTracing?: boolean;
   readonly injectLogContext?: boolean;
+}
+
+enum TagKeys {
+  Cdk = "dd_cdk_construct",
 }
 
 export class Datadog extends cdk.Construct {
@@ -79,11 +84,22 @@ export class Datadog extends cdk.Construct {
       } else {
         log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
       }
+      addCdkTag(lambdaFunctions);
       applyEnvVariables(lambdaFunctions, enableDatadogTracing, injectLogContext);
 
       this.transport.applyEnvVars(lambdaFunctions);
     }
   }
+}
+
+/**
+ * Tags the function(s) with DD Cdk version
+ */
+export function addCdkTag(lambdaFunctions: lambda.Function[]) {
+  log.debug(`Adding CDK Version ${version}`);
+  lambdaFunctions.forEach((functionName) => {
+    cdk.Tags.of(functionName).add(TagKeys.Cdk, `v${version}`, { includeResourceTypes: ["AWS::Lambda::Function"] });
+  });
 }
 
 function validateProps(props: DatadogProps) {

--- a/test/datadog.spec.ts
+++ b/test/datadog.spec.ts
@@ -2,6 +2,7 @@ import * as lambda from "@aws-cdk/aws-lambda";
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
 import { Datadog, addCdkTag } from "../src/index";
+const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
 const NODE_LAYER_VERSION = 1;
 
@@ -178,7 +179,7 @@ describe("addCdkTag", () => {
       Tags: [
         {
           Key: "dd_cdk_construct",
-          Value: "v[object Object]",
+          Value: `v${versionJson.version}`,
         },
       ],
     });
@@ -187,7 +188,7 @@ describe("addCdkTag", () => {
       Tags: [
         {
           Key: "dd_cdk_construct",
-          Value: "v[object Object]",
+          Value: `v${versionJson.version}`,
         },
       ],
     });

--- a/test/datadog.spec.ts
+++ b/test/datadog.spec.ts
@@ -1,7 +1,7 @@
 import * as lambda from "@aws-cdk/aws-lambda";
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
-import { Datadog } from "../src/index";
+import { Datadog, addCdkTag } from "../src/index";
 const EXTENSION_LAYER_VERSION = 5;
 const NODE_LAYER_VERSION = 1;
 
@@ -151,5 +151,45 @@ describe("validateProps", () => {
     }
     expect(threwError).toBe(true);
     expect(thrownError?.message).toEqual("When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.");
+  });
+});
+
+describe("addCdkTag", () => {
+  it("adds the dd_cdk_construct tag to all lambda function", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const hello1 = new lambda.Function(stack, "HelloHandler1", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const hello2 = new lambda.Function(stack, "HelloHandler2", {
+      runtime: lambda.Runtime.PYTHON_3_8,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    addCdkTag([hello1, hello2]);
+    expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+      Runtime: "nodejs10.x",
+      Tags: [
+        {
+          Key: "dd_cdk_construct",
+          Value: "v[object Object]",
+        },
+      ],
+    });
+    expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
+      Runtime: "python3.8",
+      Tags: [
+        {
+          Key: "dd_cdk_construct",
+          Value: "v[object Object]",
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR adds a CDK Version tag to each Lambda Function that is instrumented via the DD CDK Construct Library.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
With [SLS-1077](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205?selectedIssue=SLS-1077) we would like to track the number of lambdas instrumented via the DD CDK with our [AWS Lambda Metadata Crawler](https://github.com/DataDog/devops/wiki/AWS-Lambda-Metadata-Crawler) and eventually have it populated in [this](https://app.datadoghq.com/dashboard/j8t-8s6-n2i/serverless-kpi-dashboard?from_ts=1618955916530&fullscreen_end_ts=1619042316530&fullscreen_paused=true&fullscreen_start_ts=1618955916530&fullscreen_widget=3730893819089948&live=false&tile_focus=3730893819089948&to_ts=1619042316530&fullscreen_section=overview) dashboard. 

The first step to get that working is to add a tag (`dd_cdk_construct`) that can be picked up by the crawler. This tag will help the crawler distinguish what Serverless Integration was used to instrument the lambda function, in this case the DD CDK Construct.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
* Added a unit test
* Manually synthesized the CDK Stack and asserted that the tag was added by viewing the CloudFormation template. See the snippet bellow:
``` Environment:
        Variables:
          DD_LAMBDA_HANDLER: hello.handler
          DD_TRACE_ENABLED: "true"
          DD_LOG_INJECTION: "true"
          DD_FLUSH_TO_LOG: "true"
          DD_API_KEY: "1234"
      Handler: /opt/nodejs/node_modules/datadog-lambda-js/handler.handler
      Layers:
        - Fn::Join:
            - ""
            - - "arn:aws:lambda:"
              - Ref: AWS::Region
              - :464622532012:layer:Datadog-Node10-x:39
      Runtime: nodejs10.x
      Tags:
        - Key: dd_cdk_construct
          Value: v0.2.1
```
<!--- How did you test this pull request? --->

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
