### PR TITLE
Fix DD_LOGS_INJECTION env var

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -10,7 +10,7 @@ import * as lambda from "@aws-cdk/aws-lambda";
 import log from "loglevel";
 
 export const enableDDTracingEnvVar = "DD_TRACE_ENABLED";
-export const injectLogContextEnvVar = "DD_LOG_INJECTION";
+export const injectLogContextEnvVar = "DD_LOGS_INJECTION";
 
 export const defaultEnvVar = {
   addLayers: true,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This corrects the `DD_LOG_INJECTION` env var to `DD_LOGS_INJECTION`. The variable is set when a user passes `injectLogContext: true` to the Datadog constructor. Both the [JS](https://github.com/datadog/datadog-lambda-js#dd_logs_injection) and [Python](https://github.com/datadog/datadog-lambda-python#dd_logs_injection) libraries expect `DD_LOGS_INJECTION`.

This fixes issue #35 

This is not a breaking change, since this has been incorrect since the beginning.

<!--- A brief description of the change being made with this pull request. --->

`DD_LOG_INJECTION` -> `DD_LOGS_INJECTION`

### Motivation

<!--- What inspired you to submit this pull request? --->

#35 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
