### PR TITLE
Improve Release Script

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -30,6 +30,22 @@ else
     VERSION=$1
 fi
 
+if ! [ -x "$(command -v yarn)" ]; then
+  echo 'Error: yarn is not installed.'
+  exit 1
+fi
+if ! [ -x "$(command -v pip)" ]; then
+  echo 'Error: pip is not installed.'
+  exit 1
+fi
+if ! [ -x "$(command -v python3)" ]; then
+  echo 'Error: python3 is not installed.'
+  exit 1
+fi
+
+# Make sure dependencies are installed before proceeding
+yarn
+
 read -p "Do you have the PyPI and npm login credentials for the Datadog account (y/n)?" CONT
 if [ "$CONT" != "y" ]; then
     echo "Exiting"

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -64,7 +64,7 @@ fi
 
 echo "Bumping the version number and committing the changes"
 if git log --oneline -1 | grep -q "chore(release):"; then
-    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message, aborting"
+    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message, this means if the script prematurely ended previously without publishing you may need to 'git reset --HARD' to a previous commit before trying again, aborting"
     exit 1
 else
     yarn standard-version --release-as $VERSION

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -23,7 +23,7 @@ CURRENT_VERSION=$(node -pe "require('./package.json').version")
 if [ -z "$1" ]; then
     echo "Must specify a desired version number"
     exit 1
-elif [[ ! $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+elif [[ ! $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Must use a semantic version, e.g., 3.1.4"
     exit 1
 else

--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -62,9 +62,14 @@ if [ "$CONT" != "y" ]; then
     exit 1
 fi
 
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+    echo "tag v${VERSION} already exists, aborting"
+    exit 1
+fi
+
 echo "Bumping the version number and committing the changes"
 if git log --oneline -1 | grep -q "chore(release):"; then
-    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message, this means if the script prematurely ended previously without publishing you may need to 'git reset --HARD' to a previous commit before trying again, aborting"
+    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message. This means if the script previously prematurely ended without publishing you may need to 'git reset --hard' to a previous commit before trying again, aborting"
     exit 1
 else
     yarn standard-version --release-as $VERSION


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR attempts to make the release script more rigid. For instance:
* I strengthened the regex to only allow digits. (When someone would call the script using `v3.1.4` it would fail because many of the commands later in the script did not expect there to be a `v` just strictly the `major.minor.patch`)
* Before going any further in the script we check to make sure the user has all the necessary terminal commands as that would be a silly way to end the script. One instance I am trying to avoid is the JS package being published but then the Python one fails because they dont have `pip` or `python3`. I would like to minimize the chance that the script fails in a critical part like the publishing to NPM and PyPi.
* Before publishing the artifacts we make sure that they actually exist. This again stops the situation of one package being published but the other failing and being out of sync.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
The script had a lot of room to fail. Failing on a release script could cause some problems therefore before doing any publishing we would like to do our best to ensure everything will run smoothly before getting to the critical parts of the script. 
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
I manually ran the script end to end on my test pypi and npm accounts (I deleted the packages right after). I asserted that the pitfalls where the script could easily fail before have checks. The release process should be smooth from now on.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
