### PR TITLE
Document Nested Stack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,57 @@ const lambda_function = new lambda.Function(this, "HelloHandler", {
 });
 ```
 
+### Nested Stacks
+
+Re-add the Datadog CDK Construct to each stack you wish to instrument with Datadog. For example below we initialize the Datadog CDK Construct and call `addLambdaFunctions()` in the `RootStack` and the `NestedStack`.
+
+```typescript
+import { Datadog } from "datadog-cdk-constructs";
+import * as cdk from "@aws-cdk/core";
+
+class RootStack extends cdk.Stack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const datadog = new Datadog(this, "Datadog", {
+      nodeLayerVersion: <LAYER_VERSION>,
+      pythonLayerVersion: <LAYER_VERSION>,
+      addLayers: <BOOLEAN>,
+      forwarderArn: "<FORWARDER_ARN>",
+      flushMetricsToLogs: <BOOLEAN>,
+      site: "<SITE>",
+      apiKey: "{Datadog_API_Key}",
+      apiKmsKey: "{Encrypted_Datadog_API_Key}",
+      enableDatadogTracing: <BOOLEAN>,
+      injectLogContext: <BOOLEAN>
+    });
+    datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>]);
+
+  }
+}
+
+class NestedStack extends cdk.NestedStack {
+  constructor(scope: cdk.Construct, id: string, props?: cdk.NestedStackProps) {
+    super(scope, id, props);
+
+    const datadog = new Datadog(this, "Datadog", {
+      nodeLayerVersion: <LAYER_VERSION>,
+      pythonLayerVersion: <LAYER_VERSION>,
+      addLayers: <BOOLEAN>,
+      forwarderArn: "<FORWARDER_ARN>",
+      flushMetricsToLogs: <BOOLEAN>,
+      site: "<SITE>",
+      apiKey: "{Datadog_API_Key}",
+      apiKmsKey: "{Encrypted_Datadog_API_Key}",
+      enableDatadogTracing: <BOOLEAN>,
+      injectLogContext: <BOOLEAN>
+    });
+    datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>]);
+
+  }
+}
+```
+
 ### Tags
 
 Add tags to your constructs. We recommend setting an `env` and `service` tag to tie Datadog telemetry together. For more information see [official AWS documentation][10] and [CDK documentation][11].

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ import { Datadog } from "datadog-cdk-constructs";
 import * as cdk from "@aws-cdk/core";
 
 class RootStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
     const datadog = new Datadog(this, "Datadog", {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ import * as cdk from "@aws-cdk/core";
 class RootStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-
+    new NestedStack(this, "NestedStack");
+    
     const datadog = new Datadog(this, "Datadog", {
       nodeLayerVersion: <LAYER_VERSION>,
       pythonLayerVersion: <LAYER_VERSION>,

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const lambda_function = new lambda.Function(this, "HelloHandler", {
 
 ### Nested Stacks
 
-Re-add the Datadog CDK Construct to each stack you wish to instrument with Datadog. For example below we initialize the Datadog CDK Construct and call `addLambdaFunctions()` in the `RootStack` and the `NestedStack`.
+Re-add the Datadog CDK Construct to each stack you wish to instrument with Datadog. For example below we initialize the Datadog CDK Construct and call `addLambdaFunctions()` in the `RootStack` and `NestedStack`.
 
 ```typescript
 import { Datadog } from "datadog-cdk-constructs";

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -73,7 +73,7 @@ describe("addLambdaFunctions", () => {
     expect(throwsError).toBe(true);
   });
 
-  it("Adds forwarder subscriptions to regular and nested CDK stacks", () => {
+  it("Adds forwarder log group subscriptions to regular and nested CDK stacks", () => {
     const app = new cdk.App();
     const RootStack = new cdk.Stack(app, "RootStack");
     const NestedStack = new cdk.NestedStack(RootStack, "NestedStack");

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,6 +2,7 @@ import * as lambda from "@aws-cdk/aws-lambda";
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
 import { Datadog, logForwardingEnvVar, enableDDTracingEnvVar, injectLogContextEnvVar } from "../src/index";
+import { DD_ACCOUNT_ID } from "../src/layer";
 import { JS_HANDLER_WITH_LAYERS, DD_HANDLER_ENV_VAR, PYTHON_HANDLER } from "../src/redirect";
 import { findDatadogSubscriptionFilters } from "./test-utils";
 
@@ -97,6 +98,40 @@ describe("addLambdaFunctions", () => {
     expect(NestedStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "forwarder-arn",
       FilterPattern: "",
+    });
+  });
+
+  it("Adds DD Lambda Extension when using nested CDK stack", () => {
+    const app = new cdk.App();
+    const RootStack = new cdk.Stack(app, "RootStack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const NestedStack = new cdk.NestedStack(RootStack, "NestedStack");
+
+    const NestedStackLambda = new lambda.Function(NestedStack, "NestedStackLambda", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+    const NestedStackDatadogCdk = new Datadog(NestedStack, "NestedStackDatadogCdk", {
+      nodeLayerVersion: 20,
+      pythonLayerVersion: 28,
+      addLayers: true,
+      extensionLayerVersion: 6,
+      apiKey: "1234",
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    NestedStackDatadogCdk.addLambdaFunctions([NestedStackLambda]);
+
+    expect(NestedStack).toHaveResource("AWS::Lambda::Function", {
+      Layers: [
+        `arn:aws:lambda:sa-east-1:${DD_ACCOUNT_ID}:layer:Datadog-Node10-x:20`,
+        `arn:aws:lambda:sa-east-1:${DD_ACCOUNT_ID}:layer:Datadog-Extension:6`,
+      ],
     });
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -73,33 +73,16 @@ describe("addLambdaFunctions", () => {
     expect(throwsError).toBe(true);
   });
 
-  it("Adds forwarder log group subscriptions to regular and nested CDK stacks", () => {
+  it("Adds a log group subscription to a lambda in a nested CDK stack", () => {
     const app = new cdk.App();
     const RootStack = new cdk.Stack(app, "RootStack");
     const NestedStack = new cdk.NestedStack(RootStack, "NestedStack");
-
-    const RootStackLambda = new lambda.Function(RootStack, "RootStackLambda", {
-      runtime: lambda.Runtime.NODEJS_10_X,
-      code: lambda.Code.fromAsset("test"),
-      handler: "hello.handler",
-    });
 
     const NestedStackLambda = new lambda.Function(NestedStack, "NestedStackLambda", {
       runtime: lambda.Runtime.NODEJS_10_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
-    const RootStackDatadogCdk = new Datadog(RootStack, "RootStackDatadogCdk", {
-      nodeLayerVersion: 20,
-      pythonLayerVersion: 28,
-      addLayers: true,
-      forwarderArn: "forwarder-arn",
-      enableDatadogTracing: true,
-      flushMetricsToLogs: true,
-      site: "datadoghq.com",
-    });
-    RootStackDatadogCdk.addLambdaFunctions([RootStackLambda]);
-
     const NestedStackDatadogCdk = new Datadog(NestedStack, "NestedStackDatadogCdk", {
       nodeLayerVersion: 20,
       pythonLayerVersion: 28,
@@ -111,10 +94,6 @@ describe("addLambdaFunctions", () => {
     });
     NestedStackDatadogCdk.addLambdaFunctions([NestedStackLambda]);
 
-    expect(RootStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
-      FilterPattern: "",
-    });
     expect(NestedStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "forwarder-arn",
       FilterPattern: "",

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -101,7 +101,7 @@ describe("addLambdaFunctions", () => {
     });
   });
 
-  it("Adds DD Lambda Extension when using nested CDK stack", () => {
+  it("Adds DD Lambda Extension when using a nested CDK stack", () => {
     const app = new cdk.App();
     const RootStack = new cdk.Stack(app, "RootStack", {
       env: {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -72,6 +72,54 @@ describe("addLambdaFunctions", () => {
     }
     expect(throwsError).toBe(true);
   });
+
+  it("Adds forwarder subscriptions to regular and nested CDK stacks", () => {
+    const app = new cdk.App();
+    const RootStack = new cdk.Stack(app, "RootStack");
+    const NestedStack = new cdk.NestedStack(RootStack, "NestedStack");
+
+    const RootStackLambda = new lambda.Function(RootStack, "RootStackLambda", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+
+    const NestedStackLambda = new lambda.Function(NestedStack, "NestedStackLambda", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+    });
+    const RootStackDatadogCdk = new Datadog(RootStack, "RootStackDatadogCdk", {
+      nodeLayerVersion: 20,
+      pythonLayerVersion: 28,
+      addLayers: true,
+      forwarderArn: "forwarder-arn",
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    RootStackDatadogCdk.addLambdaFunctions([RootStackLambda]);
+
+    const NestedStackDatadogCdk = new Datadog(NestedStack, "NestedStackDatadogCdk", {
+      nodeLayerVersion: 20,
+      pythonLayerVersion: 28,
+      addLayers: true,
+      forwarderArn: "forwarder-arn",
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    NestedStackDatadogCdk.addLambdaFunctions([NestedStackLambda]);
+
+    expect(RootStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
+      DestinationArn: "forwarder-arn",
+      FilterPattern: "",
+    });
+    expect(NestedStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
+      DestinationArn: "forwarder-arn",
+      FilterPattern: "",
+    });
+  });
 });
 
 describe("applyLayers", () => {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR documents how to enable the DD CDK Construct on nested stacks.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
We got a feature request for nested stacks in [SLS-1104](https://datadoghq.atlassian.net/jira/software/projects/SLS/boards/205?selectedIssue=SLS-1104). However after some testing I concluded that nested stacks are supported, the user just has to re-add the Datadog CDK Construct to each stack whether or not its a nested or regular CDK stack.

Checkout [this](https://dd.slack.com/archives/GHQ114DRR/p1620164676032100) slack thread for more context on why we decided to just document the current way of using nested stacks.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
I manually created nested stacks and made sure the DD CDK Construct worked on both by checking out the deployed resources.
I also added a test which asserts that forwarder log group subscriptions/DD Lambda Extension are added when using nested CDK stacks.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
