### PR TITLE
Improve publish script by moving pip command earlier in script

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -38,6 +38,7 @@ if ! [ -x "$(command -v pip)" ]; then
   echo 'Error: pip is not installed.'
   exit 1
 fi
+pip install --upgrade twine
 if ! [ -x "$(command -v python3)" ]; then
   echo 'Error: python3 is not installed.'
   exit 1
@@ -103,7 +104,6 @@ echo "Publishing to npm"
 yarn publish $JS_TARBALL --new-version "$VERSION"
 
 echo "Publishing to PyPI"
-pip install --upgrade twine
 python3 -m twine upload ./dist/python/*
 
 echo 'Pushing updates to github'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR moves the `pip install --upgrade twine` command to a less critical part of the publish script.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
While pairing with team members to make a release to the DD CDK we encountered an issue with the release script, the pip version I used to create the script was different than the version the person running the script was using that caused the `pip install --upgrade twine` command to prematurely terminate the script because it couldn't find `twine`.

Having the possibility that the script can fail after publishing to npm but before publishing to PyPi could cause issues. Therefore in order to minimize the chance that that happens I think its a better idea to move the pip install command higher in the script so that if it fails it wont be at a critical part of the script. 
<!--- What inspired you to submit this pull request? --->

### Additional Notes
I tried to add some logic to make sure the users pip version is greater than or equal to the version used to create the script but I couldn't get it working. Moving the pip install command higher should mean that we wont have an issue of one package being published and the other not as the script will end before all publishing steps if there is a problem with the users environment.
<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
