### PR TITLE
Allow usage of addForwarderToLogGroups on log groups imported using from functions

### DIFF
--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -104,7 +104,7 @@ export class Datadog extends cdk.Construct {
     }
   }
 
-  public addForwarderToNonLambdaLogGroups(logGroups: logs.LogGroup[]) {
+  public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {
     if (this.props.forwarderArn !== undefined) {
       addForwarderToLogGroups(this.scope, logGroups, this.props.forwarderArn);
     } else {

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -8,7 +8,7 @@
 
 import * as crypto from "crypto";
 import * as lambda from "@aws-cdk/aws-lambda";
-import { FilterPattern, LogGroup } from "@aws-cdk/aws-logs";
+import { FilterPattern, ILogGroup } from "@aws-cdk/aws-logs";
 import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
 export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
@@ -56,11 +56,11 @@ export function addForwarder(scope: cdk.Construct, lambdaFunctions: lambda.Funct
   });
 }
 
-export function addForwarderToLogGroups(scope: cdk.Construct, logGroups: LogGroup[], forwarderArn: string) {
+export function addForwarderToLogGroups(scope: cdk.Construct, logGroups: ILogGroup[], forwarderArn: string) {
   const forwarder = getForwarder(scope, forwarderArn);
   const forwarderDestination = new LambdaDestination(forwarder);
   logGroups.forEach((group) => {
-    const subscriptionFilterName = generateSubscriptionFilterName(cdk.Names.uniqueId(group), forwarderArn);
+    const subscriptionFilterName = generateSubscriptionFilterName(cdk.Names.nodeUniqueId(group.node), forwarderArn);
     group.addSubscriptionFilter(subscriptionFilterName, {
       destination: forwarderDestination,
       filterPattern: FilterPattern.allEvents(),

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -16,7 +16,7 @@ export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 // once https://github.com/aws/aws-cdk/pull/14222 is merged and released.
 import { LambdaDestination } from "./lambdaDestination";
 
-function generateForwaderConstructId(forwarderArn: string) {
+function generateForwarderConstructId(forwarderArn: string) {
   log.debug("Generating construct Id for Datadog Lambda Forwarder");
   return "forwarder" + crypto.createHash("sha256").update(forwarderArn).digest("hex");
 }
@@ -35,7 +35,7 @@ function generateSubscriptionFilterName(functionUniqueId: string, forwarderArn: 
 }
 
 function getForwarder(scope: cdk.Construct, forwarderArn: string) {
-  const forwarderConstructId = generateForwaderConstructId(forwarderArn);
+  const forwarderConstructId = generateForwarderConstructId(forwarderArn);
   if (scope.node.tryFindChild(forwarderConstructId)) {
     return scope.node.tryFindChild(forwarderConstructId) as lambda.IFunction;
   } else {

--- a/test/forwarder.spec.ts
+++ b/test/forwarder.spec.ts
@@ -180,6 +180,20 @@ describe("Forwarder", () => {
       FilterPattern: "",
     });
   });
+  it("Subscribes the forwarder to an imported log group via the addForwarderToLogGroups function", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const logGroup = LogGroup.fromLogGroupName(stack, "LogGroup", "logGroupName");
+    addForwarderToLogGroups(stack, [logGroup], "forwarder-arn");
+    expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
+      DestinationArn: "forwarder-arn",
+      FilterPattern: "",
+    });
+  });
   it("Subscribes the forwarder to multiple log groups via the addForwarderToLogGroups function", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "stack", {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

When using aws-logs `from` functions, such as `fromLogGroupName`, an ILogGroup is returned. This PR changes `addForwarderToLogGroups` to use an `ILogGroup` parameter instead of a `LogGroup`, creating compatibility with imported log groups.

I've also corrected a minor spelling typo.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->
I wanted to use the construct with imported log groups.

### Testing Guidelines

<!--- How did you test this pull request? --->
Added unit test.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
