### PR TITLE
Stop testing against Node 10, start testing against Node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        node-version: [10,12,14]
+        node-version: [12,14,16]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### What does this PR do?

Previously, we ran the unit tests against Node 10, 12, and 14. Node 10 reached end of life on April 30, 2021 and is no longer receiving any updates. Meanwhile, the current version of Node is 16, and will become the LTS release on October 26, 2021. We should adjust which versions we test against accordingly.

See [here](https://nodejs.org/en/about/releases/) for more information about Node versions.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
