### PR TITLE
Adding support for DD_API_KEY_SECRET_ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const datadog = new Datadog(this, "Datadog", {
   site: "<SITE>",
   apiKey: "{Datadog_API_Key}",
   apiKmsKey: "{Encrypted_Datadog_API_Key}",
+  apiKeySecretArn: "{Secret_ARN_For_Datadog_API_Key}",
   enableDatadogTracing: <BOOLEAN>,
   enableDatadogLogs: <BOOLEAN>,
   injectLogContext: <BOOLEAN>,
@@ -71,12 +72,13 @@ _Note_: The descriptions use the npm package parameters, but they also apply to 
 | `addLayers` | `add_layers` | Whether to add the Lambda Layers or expect the user to bring their own. Defaults to true. When true, the Lambda Library version variables are also required. When false, you must include the Datadog Lambda library in your functions' deployment packages. |
 | `pythonLayerVersion` | `python_layer_version` | Version of the Python Lambda layer to install, such as 21. Required if you are deploying at least one Lambda function written in Python and `addLayers` is true. Find the latest version number [here][5]. |
 | `nodeLayerVersion` | `node_layer_version` | Version of the Node.js Lambda layer to install, such as 29. Required if you are deploying at least one Lambda function written in Node.js and `addLayers` is true. Find the latest version number from [here][6]. |
-| `extensionLayerVersion` | `extension_layer_version` | Version of the Datadog Lambda Extension layer to install, such as 5. When `extensionLayerVersion` is set, `apiKey` (or `apiKmsKey` ) needs to be set as well. When enabled, lambda function log groups will not be subscribed by the forwarder. Learn more about the Lambda extension [here][12]. |
+| `extensionLayerVersion` | `extension_layer_version` | Version of the Datadog Lambda Extension layer to install, such as 5. When `extensionLayerVersion` is set, `apiKey` (or `apiKmsKey` or `apiKeySecretArn` ) needs to be set as well. When enabled, lambda function log groups will not be subscribed by the forwarder. Learn more about the Lambda extension [here][12]. |
 | `forwarderArn` | `forwarder_arn` | When set, the plugin will automatically subscribe the Datadog Forwarder to the functions' log groups. Do not set `forwarderArn` when `extensionLayerVersion` is set. |
-| `flushMetricsToLogs` | `flush_metrics_to_logs` | Send custom metrics using CloudWatch logs with the Datadog Forwarder Lambda function (recommended). Defaults to `true` . If you disable this parameter, it's required to set `apiKey` (or `apiKmsKey` ). |
+| `flushMetricsToLogs` | `flush_metrics_to_logs` | Send custom metrics using CloudWatch logs with the Datadog Forwarder Lambda function (recommended). Defaults to `true` . If you disable this parameter, it's required to set `apiKey` (or `apiKmsKey` or `apiKeySecretArn` ). |
 | `site` | `site` | Set which Datadog site to send data. This is only used when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set. Possible values are `datadoghq.com` , `datadoghq.eu` , `us3.datadoghq.com` and `ddog-gov.com`. The default is `datadoghq.com`. |
 | `apiKey` | `api_key` | Datadog API Key, only needed when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set. For more information about getting a Datadog API key, see the [API key documentation][8]. |
 | `apiKmsKey` | `api_kms_key` | Datadog API Key encrypted using KMS. Use this parameter in place of `apiKey` when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set, and you are using KMS encryption. |
+| `apiKeySecretArn` | `api_key_secret_arn` | Datadog API Key stored in secrets manager. Use this parameter in place of `apiKey` when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set, and you are using secret manager for storing the api key. |
 | `enableDatadogTracing` | `enable_datadog_tracing` | Enable Datadog tracing on your Lambda functions. Defaults to `true`. |
 | `enableDatadogLogs` | `enable_datadog_logs` | Send Lambda function logs to Datadog via the Datadog Lambda Extension.  Defaults to `true`. Note: This setting has no effect on logs sent via the Datadog Forwarder. |
 | `injectLogContext` | `inject_log_context` | When set, the Lambda layer will automatically patch console.log with Datadog's tracing ids. Defaults to `true`. |
@@ -119,6 +121,7 @@ class RootStack extends cdk.Stack {
       site: "<SITE>",
       apiKey: "{Datadog_API_Key}",
       apiKmsKey: "{Encrypted_Datadog_API_Key}",
+      apiKeySecretArn: "{Secret_ARN_For_Datadog_API_Key}",
       enableDatadogTracing: <BOOLEAN>,
       enableDatadogLogs: <BOOLEAN>,
       injectLogContext: <BOOLEAN>
@@ -141,6 +144,7 @@ class NestedStack extends cdk.NestedStack {
       site: "<SITE>",
       apiKey: "{Datadog_API_Key}",
       apiKmsKey: "{Encrypted_Datadog_API_Key}",
+      apiKeySecretArn: "{Secret_ARN_For_Datadog_API_Key}",
       enableDatadogTracing: <BOOLEAN>,
       enableDatadogLogs: <BOOLEAN>,
       injectLogContext: <BOOLEAN>

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -11,6 +11,7 @@ import log from "loglevel";
 
 export const API_KEY_ENV_VAR = "DD_API_KEY";
 export const KMS_API_KEY_ENV_VAR = "DD_KMS_API_KEY";
+export const API_KEY_SECRET_ARN_ENV_VAR = "DD_API_KEY_SECRET_ARN";
 export const SITE_URL_ENV_VAR = "DD_SITE";
 export const FLUSH_METRICS_TO_LOGS_ENV_VAR = "DD_FLUSH_TO_LOG";
 
@@ -25,6 +26,7 @@ export class Transport {
   site: string;
   apiKey?: string;
   apiKmsKey?: string;
+  apiKeySecretArn?: string;
   extensionLayerVersion?: number;
 
   constructor(
@@ -32,6 +34,7 @@ export class Transport {
     site?: string,
     apiKey?: string,
     apiKmsKey?: string,
+    apiKeySecretArn?: string,
     extensionLayerVersion?: number,
   ) {
     if (flushMetricsToLogs === undefined) {
@@ -57,6 +60,7 @@ export class Transport {
 
     this.apiKey = apiKey;
     this.apiKmsKey = apiKmsKey;
+    this.apiKeySecretArn = apiKeySecretArn;
   }
 
   applyEnvVars(lambdas: lambda.Function[]) {
@@ -71,6 +75,9 @@ export class Transport {
       }
       if (this.apiKmsKey !== undefined) {
         lam.addEnvironment(KMS_API_KEY_ENV_VAR, this.apiKmsKey);
+      }
+      if (this.apiKeySecretArn !== undefined) {
+        lam.addEnvironment(API_KEY_SECRET_ARN_ENV_VAR, this.apiKeySecretArn);
       }
     });
   }

--- a/test/datadog.spec.ts
+++ b/test/datadog.spec.ts
@@ -29,7 +29,7 @@ describe("validateProps", () => {
         apiKmsKey: "5678",
       });
       datadogCDK.addLambdaFunctions([hello]);
-    }).toThrowError("Both `apiKey` and `apiKmsKey` cannot be set.");
+    }).toThrowError("Only one of `apiKey`, `apiKmsKey`, and `apiKeySecretArn` can be set.");
   });
 
   it("throws an error when the site is set to an invalid site URL", () => {
@@ -85,7 +85,9 @@ describe("validateProps", () => {
         site: "datadoghq.com",
       });
       datadogCDK.addLambdaFunctions([hello]);
-    }).toThrowError("When `flushMetricsToLogs` is false, `apiKey` or `apiKmsKey` must also be set.");
+    }).toThrowError(
+      "When `flushMetricsToLogs` is false, `apiKey`, `apiKmsKey`, or `apiKeySecretArn` must also be set.",
+    );
   });
 
   it("throws an error when the `extensionLayerVersion` is set and neither the `apiKey` nor `apiKmsKey` is set", () => {
@@ -117,7 +119,9 @@ describe("validateProps", () => {
       thrownError = e;
     }
     expect(threwError).toBe(true);
-    expect(thrownError?.message).toEqual("When `extensionLayer` is set, `apiKey` or `apiKmsKey` must also be set.");
+    expect(thrownError?.message).toEqual(
+      "When `extensionLayer` is set, `apiKey`, `apiKmsKey`, or `apiKeySecretArn` must also be set.",
+    );
   });
 });
 

--- a/test/transport.spec.ts
+++ b/test/transport.spec.ts
@@ -5,6 +5,7 @@ import {
   Datadog,
   API_KEY_ENV_VAR,
   KMS_API_KEY_ENV_VAR,
+  API_KEY_SECRET_ARN_ENV_VAR,
   SITE_URL_ENV_VAR,
   FLUSH_METRICS_TO_LOGS_ENV_VAR,
   ENABLE_DD_TRACING_ENV_VAR,
@@ -343,6 +344,42 @@ describe("apiKMSKeyEnvVar", () => {
           [ENABLE_DD_LOGS_ENV_VAR]: "true",
           [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
           [KMS_API_KEY_ENV_VAR]: "5678",
+        },
+      },
+    });
+  });
+});
+
+describe("apiKeySecretArnEnvVar", () => {
+  it("adds DD_API_KEY_SECRET_ARN environment variable", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_10_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogCDK = new Datadog(stack, "Datadog", {
+      forwarderArn: "forwarder-arn",
+      flushMetricsToLogs: false,
+      site: "datadoghq.com",
+      apiKeySecretArn: "91011",
+    });
+    datadogCDK.addLambdaFunctions([hello]);
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          [DD_HANDLER_ENV_VAR]: "hello.handler",
+          [SITE_URL_ENV_VAR]: "datadoghq.com",
+          [FLUSH_METRICS_TO_LOGS_ENV_VAR]: "false",
+          [ENABLE_DD_TRACING_ENV_VAR]: "true",
+          [ENABLE_DD_LOGS_ENV_VAR]: "true",
+          [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
+          [API_KEY_SECRET_ARN_ENV_VAR]: "91011",
         },
       },
     });


### PR DESCRIPTION
### What does this PR do?
This PR adds support for DD_API_KEY_SECRET_ARN for the lambda extension.

### Motivation
We have the datadog api key stored in secrets manager, and want to use the datadog cdk construct for easier deployment and management of our lambda functions.

### Testing Guidelines
Only unit tests.

### Additional Notes
None that I can think of

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
