### PR TITLE
Add support for Python 3.9

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -23,16 +23,15 @@ const extensionLayerPrefix = "DatadogExtension";
 export const runtimeLookup: { [key: string]: RuntimeType } = {
   "nodejs10.x": RuntimeType.NODE,
   "nodejs12.x": RuntimeType.NODE,
-  "nodejs8.10": RuntimeType.NODE,
   "nodejs14.x": RuntimeType.NODE,
   "python2.7": RuntimeType.PYTHON,
   "python3.6": RuntimeType.PYTHON,
   "python3.7": RuntimeType.PYTHON,
   "python3.8": RuntimeType.PYTHON,
+  "python3.9": RuntimeType.PYTHON,
 };
 
 const runtimeToLayerName: { [key: string]: string } = {
-  "nodejs8.10": "Datadog-Node8-10",
   "nodejs10.x": "Datadog-Node10-x",
   "nodejs12.x": "Datadog-Node12-x",
   "nodejs14.x": "Datadog-Node14-x",
@@ -40,6 +39,7 @@ const runtimeToLayerName: { [key: string]: string } = {
   "python3.6": "Datadog-Python36",
   "python3.7": "Datadog-Python37",
   "python3.8": "Datadog-Python38",
+  "python3.9": "Datadog-Python39",
 };
 
 const layers: Map<string, lambda.ILayerVersion> = new Map();


### PR DESCRIPTION
### What does this PR do?

- Add support for the Python 3.9 runtime
- Remove support for Node 8.10 runtime. This is not a breaking change because it has not been possible to update or create a Lambda function using this runtime since March 6, 2020.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
