### PR TITLE
Install twine using pip3 in publish script

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -38,7 +38,7 @@ if ! [ -x "$(command -v pip)" ]; then
   echo 'Error: pip is not installed.'
   exit 1
 fi
-pip install --upgrade twine
+pip3 install --upgrade twine
 if ! [ -x "$(command -v python3)" ]; then
   echo 'Error: python3 is not installed.'
   exit 1


### PR DESCRIPTION
### What does this PR do?

In the `publish_prod` script, install twine using pip3 instead of pip.

### Motivation

Because we run `twine` with `python3`, it should be installed with `pip3`.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
