### PR TITLE
SLS-1692: Add source code integration feature for v1 and v2 CDK

### DIFF
--- a/common/env.ts
+++ b/common/env.ts
@@ -7,13 +7,20 @@
  */
 
 import log from "loglevel";
-import { ILambdaFunction, DatadogStrictProps } from "./interfaces";
+import { DatadogStrictProps, ILambdaFunction } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
 export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL";
 export const ENABLE_DD_LOGS_ENV_VAR = "DD_SERVERLESS_LOGS_ENABLED";
 export const CAPTURE_LAMBDA_PAYLOAD_ENV_VAR = "DD_CAPTURE_LAMBDA_PAYLOAD";
+export const DD_TAGS = "DD_TAGS";
+
+export function setGitCommitHashEnvironmentVariable(lambdas: ILambdaFunction[], hash: string) {
+  lambdas.forEach((lambda) => {
+    lambda.addEnvironment(DD_TAGS, "git.commit.sha:" + hash);
+  });
+}
 
 export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: DatadogStrictProps) {
   log.debug(`Setting environment variables...`);

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -52,7 +52,7 @@ export class Datadog extends cdk.Construct {
   }
 
   public addLambdaFunctions(
-    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[]
+    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
   ) {
     const baseProps: DatadogStrictProps = handleSettingPropDefaults(this.props);
 
@@ -92,7 +92,7 @@ export class Datadog extends cdk.Construct {
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
     gitCommitSha: string,
   ) {
-    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha)
+    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -14,16 +14,17 @@ import * as cdk from "@aws-cdk/core";
 import log from "loglevel";
 import { Transport } from "./common/transport";
 import {
-  applyLayers,
-  redirectHandlers,
   addForwarder,
   addForwarderToLogGroups,
   applyEnvVariables,
-  validateProps,
-  TagKeys,
+  applyLayers,
   DatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
+  redirectHandlers,
+  setGitCommitHashEnvironmentVariable,
+  TagKeys,
+  validateProps,
 } from "./index";
 
 const versionJson = require("../version.json");
@@ -51,7 +52,7 @@ export class Datadog extends cdk.Construct {
   }
 
   public addLambdaFunctions(
-    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[]
   ) {
     const baseProps: DatadogStrictProps = handleSettingPropDefaults(this.props);
 
@@ -85,6 +86,13 @@ export class Datadog extends cdk.Construct {
 
       this.transport.applyEnvVars(lambdaFunctions);
     }
+  }
+
+  public addGitCommitMetadata(
+    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    gitCommitSha: string,
+  ) {
+    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha)
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -25,6 +25,7 @@ import {
   DatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
+  setGitCommitHashEnvironmentVariable,
 } from "./index";
 
 const versionJson = require("../version.json");
@@ -88,6 +89,13 @@ export class Datadog extends Construct {
 
       this.transport.applyEnvVars(lambdaFunctions);
     }
+  }
+
+  public addGitCommitMetadata(
+    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    gitCommitSha: string,
+  ) {
+    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR adds a new public function to the CDK that is to be called by the user to add git metadata to their lambda. Unfortunately due to CDK constraints we were unable to do this automatically and it requires the user to call an additional function to enable this feature. This feature should be used by importing `@datadog/datadog-ci` and passing in the results of `uploadGitMetadata` to `addGitCommitMetadata`. Documentation will be added in a future PR.

This feature is optional and is not a breaking change.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Adds support for source code integration.

### Testing Guidelines

This feature has unit tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
