### PR TITLE
Allow consecutive releases

### DIFF
--- a/v1/scripts/publish_prod.sh
+++ b/v1/scripts/publish_prod.sh
@@ -74,17 +74,21 @@ if [ "$CONT" != "y" ]; then
 fi
 
 if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-    echo "tag v${VERSION} already exists, aborting"
+    echo "tag v${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete tag before trying again."
     exit 1
 fi
 
-echo "Bumping package version, updating CHANGELOG.md, and committing changes"
 if git log --oneline -1 | grep -q "chore(release):"; then
-    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message. This means if the script previously prematurely ended without publishing you may need to 'git reset --hard' to a previous commit before trying again, aborting"
-    exit 1
-else
-    yarn standard-version --release-as $VERSION
+    echo "The previous commit was a release, 'chore(release):' is in the commit message. If the script previously prematurely ended without publishing you may need to 'git reset --hard' to a previous commit before trying again."
+    read -p "Proceed anyways (y/n)?" CONT
+    if [ "$CONT" != "y" ]; then
+        echo "Exiting"
+        exit 1
+    fi
 fi
+
+echo "Bumping package version, updating CHANGELOG.md, and committing changes"
+yarn standard-version --release-as $VERSION
 
 echo "Building artifacts"
 yarn build

--- a/v1/scripts/publish_prod.sh
+++ b/v1/scripts/publish_prod.sh
@@ -74,7 +74,7 @@ if [ "$CONT" != "y" ]; then
 fi
 
 if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
-    echo "tag v${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete tag before trying again."
+    echo "tag v${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete the tag before trying again."
     exit 1
 fi
 

--- a/v2/scripts/publish_prod.sh
+++ b/v2/scripts/publish_prod.sh
@@ -74,7 +74,7 @@ if [ "$CONT" != "y" ]; then
 fi
 
 if git rev-parse "v2-${VERSION}" >/dev/null 2>&1; then
-    echo "tag v2-${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete tag before trying again."
+    echo "tag v2-${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete the tag before trying again."
     exit 1
 fi
 

--- a/v2/scripts/publish_prod.sh
+++ b/v2/scripts/publish_prod.sh
@@ -74,18 +74,21 @@ if [ "$CONT" != "y" ]; then
 fi
 
 if git rev-parse "v2-${VERSION}" >/dev/null 2>&1; then
-    echo "tag v2-${VERSION} already exists, aborting"
+    echo "tag v2-${VERSION} already exists, aborting. If the script previously prematurely ended without publishing, make sure to delete tag before trying again."
     exit 1
+fi
+
+if git log --oneline -1 | grep -q "chore(release):"; then
+    echo "The previous commit was a release, 'chore(release):' is in the commit message. If the script previously prematurely ended without publishing you may need to 'git reset --hard' to a previous commit before trying again."
+    read -p "Proceed anyways (y/n)?" CONT
+    if [ "$CONT" != "y" ]; then
+        echo "Exiting"
+        exit 1
+    fi
 fi
 
 echo "Bumping package version, updating CHANGELOG.md, and committing changes"
-if git log --oneline -1 | grep -q "chore(release):"; then
-    echo "Create a new commit before attempting to release. Be sure to not include 'chore(release):' in the commit message. This means if the script previously prematurely ended without publishing you may need to 'git reset --hard' to a previous commit before trying again, aborting"
-    exit 1
-else
-    yarn standard-version --tag-prefix "v2-" --release-as $VERSION
-fi
-
+yarn standard-version --tag-prefix "v2-" --release-as $VERSION
 
 echo "Building artifacts"
 yarn build


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
Previously, both v1 and v2 `publish_prod.sh` release scripts would abort if the previous commit was a release (if the previous commit's message started with `chore(release):`). 

This PR adds the option to continue anyways.

### Motivation

<!--- What inspired you to submit this pull request? --->

Previously If you want to publish v1 and v2 packages consecutively, you would need to create a dummy commit before releasing the second package. This fixes that.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
