### PR TITLE
Bump @aws-cdk/aws-lambda-python-alpha@ to ^2.24.0-alpha.0

### DIFF
--- a/v2/.projen/deps.json
+++ b/v2/.projen/deps.json
@@ -2,6 +2,7 @@
   "dependencies": [
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
+      "version": "2.24.0-alpha.0",
       "type": "build"
     },
     {
@@ -114,6 +115,7 @@
     },
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
+      "version": "^2.24.0-alpha.0",
       "type": "peer"
     },
     {

--- a/v2/.projenrc.js
+++ b/v2/.projenrc.js
@@ -20,7 +20,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     distName: "datadog-cdk-constructs-v2",
     module: "datadog_cdk_constructs_v2",
   },
-  peerDeps: ["@aws-cdk/aws-lambda-python-alpha"],
+  peerDeps: ["@aws-cdk/aws-lambda-python-alpha@^2.24.0-alpha.0"],
   cdkVersion: "2.24.0",
   deps: ["loglevel"],
   bundledDeps: ["loglevel"],

--- a/v2/package.json
+++ b/v2/package.json
@@ -31,7 +31,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.1",
+    "@aws-cdk/aws-lambda-python-alpha": "2.24.0-alpha.0",
     "@types/jest": "^27.4.0",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -58,7 +58,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.0.0-alpha.1",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.24.0-alpha.0",
     "aws-cdk-lib": "^2.24.0",
     "constructs": "^10.0.5"
   },
@@ -76,7 +76,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "version": "0.3.2",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/package.json
+++ b/v2/package.json
@@ -76,7 +76,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.3.2",
+  "version": "0.0.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/yarn.lock
+++ b/v2/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/aws-lambda-python-alpha@^2.0.0-alpha.1":
-  version "2.0.0-rc.24"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.0.0-rc.24.tgz#8732258e210efd7380843ff9485905ec177dd722"
-  integrity sha512-XPjIdWJigzCFkYCGCjvdDGyfKzBU26ULf40oMkVAyN5Gr8CJfk+Y0ymM3rY0I7/zGgxVrxC1JhogNdp9HaT04w==
+"@aws-cdk/aws-lambda-python-alpha@2.24.0-alpha.0":
+  version "2.24.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.24.0-alpha.0.tgz#8ebe65bdad73101527d765fdc0d4938c6d898f1d"
+  integrity sha512-cfFjC7/SXgCmHhMUmKZ5z2Bkm7PX3QxRtwGP/iMSac5NLBlIoGFbplB2lljbPskxuz8FPVuesCMtXTt2IaE92g==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Bumps the construct peerdep to @aws-cdk/aws-lambda-python-alpha@^2.24.0-alpha.0

### Motivation

This should fix https://github.com/DataDog/datadog-cdk-constructs/issues/91

### Testing Guidelines

Deployed successfully with a demo TS CDK app and `"@aws-cdk/aws-lambda-python-alpha": "^2.24.0-alpha.0"`

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
