### PR TITLE
fix: ensure addLayers=false prevents layers being added

### DIFF
--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -60,14 +60,16 @@ export class Datadog extends cdk.Construct {
     if (this.props !== undefined && lambdaFunctions.length > 0) {
       const region = `${lambdaFunctions[0].env.region}`;
       log.debug(`Using region: ${region}`);
-      applyLayers(
-        this.scope,
-        region,
-        lambdaFunctions,
-        this.props.pythonLayerVersion,
-        this.props.nodeLayerVersion,
-        this.props.extensionLayerVersion,
-      );
+      if (baseProps.addLayers) {
+        applyLayers(
+          this.scope,
+          region,
+          lambdaFunctions,
+          this.props.pythonLayerVersion,
+          this.props.nodeLayerVersion,
+          this.props.extensionLayerVersion,
+        );
+      }
       redirectHandlers(lambdaFunctions, baseProps.addLayers);
 
       if (this.props.forwarderArn !== undefined) {

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -63,14 +63,16 @@ export class Datadog extends Construct {
     if (this.props !== undefined && lambdaFunctions.length > 0) {
       const region = `${lambdaFunctions[0].env.region}`;
       log.debug(`Using region: ${region}`);
-      applyLayers(
-        this.scope,
-        region,
-        lambdaFunctions,
-        this.props.pythonLayerVersion,
-        this.props.nodeLayerVersion,
-        this.props.extensionLayerVersion,
-      );
+      if (baseProps.addLayers) {
+        applyLayers(
+          this.scope,
+          region,
+          lambdaFunctions,
+          this.props.pythonLayerVersion,
+          this.props.nodeLayerVersion,
+          this.props.extensionLayerVersion,
+        );
+      }
       redirectHandlers(lambdaFunctions, baseProps.addLayers);
 
       if (this.props.forwarderArn !== undefined) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
This PR causes the `addLayers` property to prevent layers being added to functions when set to `false`

<!--- A brief description of the change being made with this pull request. --->

### Motivation
The existing behaviour of adding layers regardless of setting but applying a different handler string did not match the implied behaviour of the property name.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Added unit test in v1 and v2 that confirms that when addLayers property is set to false, no layers are added to the CDK lambda resource

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
