### PR TITLE
SLS-2345: Fix overwriting DD_TAGS when using source code integration

### DIFF
--- a/common/env.ts
+++ b/common/env.ts
@@ -7,11 +7,7 @@
  */
 
 import log from "loglevel";
-import {
-  DatadogProps,
-  DatadogStrictProps,
-  ILambdaFunction,
-} from "./interfaces";
+import { DatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
@@ -23,52 +19,31 @@ export const DD_SERVICE_ENV_VAR = "DD_SERVICE";
 export const DD_VERSION_ENV_VAR = "DD_VERSION";
 export const DD_TAGS = "DD_TAGS";
 
-export function setGitCommitHashEnvironmentVariable(
-  lambdas: any[],
-  hash: string
-) {
+export function setGitCommitHashEnvironmentVariable(lambdas: any[], hash: string) {
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lambda) => {
     if (lambda.environment[DD_TAGS] !== undefined) {
       lambda.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
     } else {
-      lambda.addEnvironment(DD_TAGS, "git.commit.sha:" + hash);
+      lambda.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
     }
   });
 }
 
-export function applyEnvVariables(
-  lambdas: ILambdaFunction[],
-  baseProps: DatadogStrictProps
-) {
+export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: DatadogStrictProps) {
   log.debug(`Setting environment variables...`);
   lambdas.forEach((lam) => {
-    lam.addEnvironment(
-      ENABLE_DD_TRACING_ENV_VAR,
-      baseProps.enableDatadogTracing.toString().toLowerCase()
-    );
-    lam.addEnvironment(
-      INJECT_LOG_CONTEXT_ENV_VAR,
-      baseProps.injectLogContext.toString().toLowerCase()
-    );
-    lam.addEnvironment(
-      ENABLE_DD_LOGS_ENV_VAR,
-      baseProps.enableDatadogLogs.toString().toLowerCase()
-    );
-    lam.addEnvironment(
-      CAPTURE_LAMBDA_PAYLOAD_ENV_VAR,
-      baseProps.captureLambdaPayload.toString().toLowerCase()
-    );
+    lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
+    lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, baseProps.injectLogContext.toString().toLowerCase());
+    lam.addEnvironment(ENABLE_DD_LOGS_ENV_VAR, baseProps.enableDatadogLogs.toString().toLowerCase());
+    lam.addEnvironment(CAPTURE_LAMBDA_PAYLOAD_ENV_VAR, baseProps.captureLambdaPayload.toString().toLowerCase());
     if (baseProps.logLevel) {
       lam.addEnvironment(LOG_LEVEL_ENV_VAR, baseProps.logLevel);
     }
   });
 }
 
-export function setDDEnvVariables(
-  lambdas: ILambdaFunction[],
-  props: DatadogProps
-) {
+export function setDDEnvVariables(lambdas: ILambdaFunction[], props: DatadogProps) {
   lambdas.forEach((lam) => {
     if (props.extensionLayerVersion) {
       if (props.env) {

--- a/common/env.ts
+++ b/common/env.ts
@@ -19,9 +19,14 @@ export const DD_SERVICE_ENV_VAR = "DD_SERVICE";
 export const DD_VERSION_ENV_VAR = "DD_VERSION";
 export const DD_TAGS = "DD_TAGS";
 
-export function setGitCommitHashEnvironmentVariable(lambdas: ILambdaFunction[], hash: string) {
+export function setGitCommitHashEnvironmentVariable(lambdas: any[], hash: string) {
+  // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lambda) => {
-    lambda.addEnvironment(DD_TAGS, "git.commit.sha:" + hash);
+    if (lambda.environment[DD_TAGS] !== undefined) {
+      lambda.environment[DD_TAGS].value += `,git.commit.sha:${hash}`
+    } else {
+      lambda.addEnvironment(DD_TAGS, "git.commit.sha:" + hash);
+    }
   });
 }
 

--- a/common/env.ts
+++ b/common/env.ts
@@ -7,7 +7,11 @@
  */
 
 import log from "loglevel";
-import { DatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
+import {
+  DatadogProps,
+  DatadogStrictProps,
+  ILambdaFunction,
+} from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
@@ -19,31 +23,52 @@ export const DD_SERVICE_ENV_VAR = "DD_SERVICE";
 export const DD_VERSION_ENV_VAR = "DD_VERSION";
 export const DD_TAGS = "DD_TAGS";
 
-export function setGitCommitHashEnvironmentVariable(lambdas: any[], hash: string) {
+export function setGitCommitHashEnvironmentVariable(
+  lambdas: any[],
+  hash: string
+) {
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lambda) => {
     if (lambda.environment[DD_TAGS] !== undefined) {
-      lambda.environment[DD_TAGS].value += `,git.commit.sha:${hash}`
+      lambda.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
     } else {
       lambda.addEnvironment(DD_TAGS, "git.commit.sha:" + hash);
     }
   });
 }
 
-export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: DatadogStrictProps) {
+export function applyEnvVariables(
+  lambdas: ILambdaFunction[],
+  baseProps: DatadogStrictProps
+) {
   log.debug(`Setting environment variables...`);
   lambdas.forEach((lam) => {
-    lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
-    lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, baseProps.injectLogContext.toString().toLowerCase());
-    lam.addEnvironment(ENABLE_DD_LOGS_ENV_VAR, baseProps.enableDatadogLogs.toString().toLowerCase());
-    lam.addEnvironment(CAPTURE_LAMBDA_PAYLOAD_ENV_VAR, baseProps.captureLambdaPayload.toString().toLowerCase());
+    lam.addEnvironment(
+      ENABLE_DD_TRACING_ENV_VAR,
+      baseProps.enableDatadogTracing.toString().toLowerCase()
+    );
+    lam.addEnvironment(
+      INJECT_LOG_CONTEXT_ENV_VAR,
+      baseProps.injectLogContext.toString().toLowerCase()
+    );
+    lam.addEnvironment(
+      ENABLE_DD_LOGS_ENV_VAR,
+      baseProps.enableDatadogLogs.toString().toLowerCase()
+    );
+    lam.addEnvironment(
+      CAPTURE_LAMBDA_PAYLOAD_ENV_VAR,
+      baseProps.captureLambdaPayload.toString().toLowerCase()
+    );
     if (baseProps.logLevel) {
       lam.addEnvironment(LOG_LEVEL_ENV_VAR, baseProps.logLevel);
     }
   });
 }
 
-export function setDDEnvVariables(lambdas: ILambdaFunction[], props: DatadogProps) {
+export function setDDEnvVariables(
+  lambdas: ILambdaFunction[],
+  props: DatadogProps
+) {
   lambdas.forEach((lam) => {
     if (props.extensionLayerVersion) {
       if (props.env) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fixes overwriting DD_TAGS when sourceCodeIntegration is enabled.

### Testing Guidelines

Unit tested

### Additional Notes

Unfortunately I've had to use an `any` type as the aws `Function` class has `environment` as a private field which we cannot overwrite.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
