### PR TITLE
fix: isARM object comparison

### DIFF
--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -35,7 +35,7 @@ export function applyLayers(
   lambdas.forEach((lam) => {
     const runtime: string = lam.runtime.name;
     const lambdaRuntimeType: RuntimeType = runtimeLookup[runtime];
-    const isARM = JSON.stringify(lam.architecture) === JSON.stringify(Architecture.ARM_64);
+    const isARM = lam.architecture.dockerPlatform === Architecture.ARM_64.dockerPlatform;
     const isNode = lambdaRuntimeType === RuntimeType.NODE;
     if (lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
       log.debug(`Unsupported runtime: ${runtime}`);

--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -35,7 +35,7 @@ export function applyLayers(
   lambdas.forEach((lam) => {
     const runtime: string = lam.runtime.name;
     const lambdaRuntimeType: RuntimeType = runtimeLookup[runtime];
-    const isARM = lam.architecture === Architecture.ARM_64;
+    const isARM = JSON.stringify(lam.architecture) === JSON.stringify(Architecture.ARM_64);
     const isNode = lambdaRuntimeType === RuntimeType.NODE;
     if (lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
       log.debug(`Unsupported runtime: ${runtime}`);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Fix comparison of `lam.architecture` and `Architecture.ARM_64`.
`Architecture.ARM_64` is an object and not ENUM.

### Motivation

Currently, it fails to fetch ARM layers from Datadog causing runtime errors in Lambdas.

### Testing Guidelines

Ran `yarn test` in v2.

### Additional Notes

We can also check Lambdas architecture like this:
`const isARM = lam.architecture.name === Architecture.ARM_64.name;`
or 
`const isARM = lam.architecture.dockerPlatform === Architecture.ARM_64.dockerPlatform;`
Not sure what you'd prefer;

### Types of Changes

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
