### PR TITLE
Default to Not Create Forwarder Permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ const datadog = new Datadog(this, "Datadog", {
   addLayers: <BOOLEAN>,
   extensionLayerVersion: "<EXTENSION_VERSION>",
   forwarderArn: "<FORWARDER_ARN>",
+  createForwarderPermissions: <BOOLEAN>,
   flushMetricsToLogs: <BOOLEAN>,
   site: "<SITE>",
   apiKey: "{Datadog_API_Key}",
@@ -130,6 +131,7 @@ _Note_: The descriptions use the npm package parameters, but they also apply to 
 | `nodeLayerVersion` | `node_layer_version` | Version of the Node.js Lambda layer to install, such as 29. Required if you are deploying at least one Lambda function written in Node.js and `addLayers` is true. Find the latest version number from [here][6]. |
 | `extensionLayerVersion` | `extension_layer_version` | Version of the Datadog Lambda Extension layer to install, such as 5. When `extensionLayerVersion` is set, `apiKey` (or if encrypted, `apiKMSKey` or `apiKeySecretArn`) needs to be set as well. When enabled, lambda function log groups will not be subscribed by the forwarder. Learn more about the Lambda extension [here][12]. |
 | `forwarderArn` | `forwarder_arn` | When set, the plugin will automatically subscribe the Datadog Forwarder to the functions' log groups. Do not set `forwarderArn` when `extensionLayerVersion` is set. |
+| `createForwarderPermissions` | `createForwarderPermissions` | When set to `true`, creates a Lambda permission on the the Datadog Forwarder per log group. Since the Datadog Forwarder has permissions configured by default, this is unnecessary in most use cases. |
 | `flushMetricsToLogs` | `flush_metrics_to_logs` | Send custom metrics using CloudWatch logs with the Datadog Forwarder Lambda function (recommended). Defaults to `true` . If you disable this parameter, it's required to set `apiKey` (or if encrypted, `apiKMSKey` or `apiKeySecretArn`). |
 | `site` | `site` | Set which Datadog site to send data. This is only used when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set. Possible values are `datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`, and `ddog-gov.com`. The default is `datadoghq.com`. |
 | `apiKey` | `api_key` | Datadog API Key, only needed when `flushMetricsToLogs` is `false` or `extensionLayerVersion` is set. For more information about getting a Datadog API key, see the [API key documentation][8]. |

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -26,6 +26,7 @@ export interface DatadogProps {
   readonly service?: string;
   readonly version?: string;
   readonly tags?: string;
+  readonly createForwarderPermissions?: boolean;
 }
 
 /*

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -80,7 +80,7 @@ export class Datadog extends Construct {
           log.debug(`Skipping adding subscriptions to the lambda log groups since the extension is enabled`);
         } else {
           log.debug(`Adding log subscriptions using provided Forwarder ARN: ${this.props.forwarderArn}`);
-          addForwarder(this.scope, lambdaFunctions, this.props.forwarderArn);
+          addForwarder(this.scope, lambdaFunctions, this.props.forwarderArn, this.props.createForwarderPermissions === true);
         }
       } else {
         log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
@@ -105,7 +105,7 @@ export class Datadog extends Construct {
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {
     if (this.props.forwarderArn !== undefined) {
-      addForwarderToLogGroups(this.scope, logGroups, this.props.forwarderArn);
+      addForwarderToLogGroups(this.scope, logGroups, this.props.forwarderArn, this.props.createForwarderPermissions === true);
     } else {
       log.debug("Forwarder ARN not provided, no non lambda log group subscriptions will be added");
     }

--- a/v2/src/forwarder.ts
+++ b/v2/src/forwarder.ts
@@ -23,9 +23,9 @@ function getForwarder(scope: Construct, forwarderArn: string) {
   }
 }
 
-export function addForwarder(scope: Construct, lambdaFunctions: lambda.Function[], forwarderArn: string) {
+export function addForwarder(scope: Construct, lambdaFunctions: lambda.Function[], forwarderArn: string, createForwarderPermissions: boolean) {
   const forwarder = getForwarder(scope, forwarderArn);
-  const forwarderDestination = new LambdaDestination(forwarder);
+  const forwarderDestination = new LambdaDestination(forwarder, { addPermissions: createForwarderPermissions, });
   lambdaFunctions.forEach((lam) => {
     const subscriptionFilterName = generateSubscriptionFilterName(Names.uniqueId(lam), forwarderArn);
     log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);
@@ -36,9 +36,9 @@ export function addForwarder(scope: Construct, lambdaFunctions: lambda.Function[
   });
 }
 
-export function addForwarderToLogGroups(scope: Construct, logGroups: ILogGroup[], forwarderArn: string) {
+export function addForwarderToLogGroups(scope: Construct, logGroups: ILogGroup[], forwarderArn: string, createForwarderPermissions: boolean) {
   const forwarder = getForwarder(scope, forwarderArn);
-  const forwarderDestination = new LambdaDestination(forwarder);
+  const forwarderDestination = new LambdaDestination(forwarder, { addPermissions: createForwarderPermissions, });
   logGroups.forEach((group) => {
     const subscriptionFilterName = generateSubscriptionFilterName(Names.nodeUniqueId(group.node), forwarderArn);
     group.addSubscriptionFilter(subscriptionFilterName, {

--- a/v2/src/sample/index.ts
+++ b/v2/src/sample/index.ts
@@ -80,6 +80,7 @@ export class ExampleStack extends Stack {
       pythonLayerVersion: 46,
       extensionLayerVersion: 10,
       // forwarderArn: "<forwarder_ARN>",
+      // createForwarderPermissions: false,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
       apiKey: process.env.API_KEY,

--- a/v2/test/forwarder.spec.ts
+++ b/v2/test/forwarder.spec.ts
@@ -15,12 +15,12 @@ describe("Forwarder", () => {
         region: "us-gov-east-1",
       },
     });
-    const pythonLambda = new lambda.Function(stack, "NodeHandler", {
+    const nodeLambda = new lambda.Function(stack, "NodeHandler", {
       runtime: lambda.Runtime.NODEJS_12_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
-    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1");
+    addForwarder(stack, [nodeLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",
       FilterPattern: "",
@@ -45,7 +45,7 @@ describe("Forwarder", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda, pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1");
+    addForwarder(stack, [nodeLambda, pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -72,8 +72,8 @@ describe("Forwarder", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda], "arn:test:forwarder:sa-east-1:12345678:1");
-    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:2");
+    addForwarder(stack, [nodeLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:2", false);
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -97,7 +97,7 @@ describe("Forwarder", () => {
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
-      addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1");
+      addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
 
       return stack;
     };
@@ -132,7 +132,7 @@ describe("Forwarder", () => {
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
-      addForwarder(stack, [pythonLambda, nodeLambda], forwarderArn);
+      addForwarder(stack, [pythonLambda, nodeLambda], forwarderArn, false);
 
       return stack;
     };
@@ -174,7 +174,7 @@ describe("Forwarder", () => {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-    addForwarderToLogGroups(stack, [restLogGroup], "arn:test:forwarder:sa-east-1:12345678:1");
+    addForwarderToLogGroups(stack, [restLogGroup], "arn:test:forwarder:sa-east-1:12345678:1", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",
       FilterPattern: "",
@@ -188,7 +188,7 @@ describe("Forwarder", () => {
       },
     });
     const logGroup = LogGroup.fromLogGroupName(stack, "LogGroup", "logGroupName");
-    addForwarderToLogGroups(stack, [logGroup], "arn:test:forwarder:sa-east-1:12345678:1");
+    addForwarderToLogGroups(stack, [logGroup], "arn:test:forwarder:sa-east-1:12345678:1", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",
       FilterPattern: "",
@@ -226,7 +226,7 @@ describe("Forwarder", () => {
       },
     });
 
-    addForwarderToLogGroups(stack, [nodeLogGroup, pythonLogGroup], "arn:test:forwarder:sa-east-1:12345678:1");
+    addForwarderToLogGroups(stack, [nodeLogGroup, pythonLogGroup], "arn:test:forwarder:sa-east-1:12345678:1", false);
     const stackSubcriptions = findDatadogSubscriptionFilters(stack);
 
     expect(stackSubcriptions).toHaveLength(2);
@@ -250,8 +250,8 @@ describe("Forwarder", () => {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1");
-    addForwarderToLogGroups(stack, [restLogGroup], "arn:test:forwarder:sa-east-1:12345678:2");
+    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarderToLogGroups(stack, [restLogGroup], "arn:test:forwarder:sa-east-1:12345678:2", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",
       FilterPattern: "",


### PR DESCRIPTION
### What does this PR do?

See #124 

The default behavior of the `LambdaDestination` AWS Log Group CDK construct is to [create a permission on the destination lambda](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_logs_destinations.LambdaDestinationOptions.html#addpermissions). While this may be desirable in many cases, the Datadog Forwarder already has permission set to allow log groups to forward their logs. Therefore, this default behavior is entirely unnecessary and problematic.

### Motivation

Stacks with large number of Lambdas, and therefore log groups, get resource quota exceeded errors trying to deploy with a Datadog Forwarder. If a stack is split up so there are fewer resources, then a new error shows up: `The final policy size [for the Datadog Forwarder] ({{ size }}) is bigger than the limit (20480)`. This means that this library cannot be used as-is with the Datadog forwarder and anything but a small number of log groups.

### Testing Guidelines

The unit tests won't create a permission resource in the test, so there's nothing to write there, aside from adding the new parameter. Manually testing using the sample, you can observe Lambda policies being created for every Lambda in the template when set to `true`, and they go away when `false`.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
