### PR TITLE
Update source code integration, git repo tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,28 +93,28 @@ datadog.addForwarderToNonLambdaLogGroups([<LOG_GROUPS>])
 
 Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/) (Typescript only), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
 
-Change your initialization function as follows (note: we're changing this to pass the `gitHash` value to the CDK):
+Change your initialization function as follows (note: we're changing this to pass the `gitHash` and `gitRepoUrl` values to the CDK):
 
 ```typescript
 async function main() {
   // Make sure to add @datadog/datadog-ci via your package manager
   const datadogCi = require("@datadog/datadog-ci");
-  const [, gitHash] = await datadogCi.gitMetadata.uploadGitCommitHash('{Datadog_API_Key}', '<SITE>')
+  const [gitRepoUrl, gitHash] = await datadogCi.gitMetadata.getGitCommitInfo()
 
   const app = new cdk.App();
   // Pass in the hash to the ExampleStack constructor
-  new ExampleStack(app, "ExampleStack", {}, gitHash);
+  new ExampleStack(app, "ExampleStack", {}, gitHash, gitRepoUrl);
 }
 ```
 
-In your stack constructor, change to add an optional `gitHash` parameter, and call `addGitCommitMetadata()`:
+In your stack constructor, change to add optional `gitHash` and `gitRepoUrl` parameters, and call `addGitCommitMetadata()`:
 
 ```typescript
 export class ExampleStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string) {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string, gitRepoUrl?:string) {
     ...
     ...
-    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash)
+    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash, gitRepoUrl)
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,69 +93,31 @@ datadog.addForwarderToNonLambdaLogGroups([<LOG_GROUPS>])
 
 Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/) (Typescript only), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
 
-Change your initialization function as follows (note: we're changing this to pass the `gitHash` and `gitRepoUrl` values to the CDK):
+Change your initialization function as follows (note: we're changing this to pass the `gitHash` value to the CDK):
 
 ```typescript
 async function main() {
   // Make sure to add @datadog/datadog-ci via your package manager
   const datadogCi = require("@datadog/datadog-ci");
-  const [gitRepoUrl, gitHash] = await datadogCi.gitMetadata.getGitCommitInfo();
+  const [, gitHash] = await datadogCi.gitMetadata.uploadGitCommitHash('{Datadog_API_Key}', '<SITE>')
 
   const app = new cdk.App();
-  // Pass in the hash and repo url to the ExampleStack constructor
-  new ExampleStack(app, "ExampleStack", {}, gitHash, gitRepoUrl);
+  // Pass in the hash to the ExampleStack constructor
+  new ExampleStack(app, "ExampleStack", {}, gitHash);
 }
 ```
 
-In your stack constructor, change to add optional `gitHash` and `gitRepoUrl` parameters, and call `addGitCommitMetadata()`:
+In your stack constructor, change to add an optional `gitHash` parameter, and call `addGitCommitMetadata()`:
 
 ```typescript
 export class ExampleStack extends cdk.Stack {
-  constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string, gitRepoUrl?:string) {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string) {
     ...
     ...
-    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash, gitRepoUrl);
+    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash)
   }
 }
 ```
-
-### Legacy Source Code Integration
-If you are using older versions of the following dependencies:
-- @datadog/datadog-ci < v2.4.0
-- datadog-cdk-constructs-v2 < v2-1.3.0
-- datadog-cdk-constructs < 0.8.4
-
-We highly encourage you to upgrade to the latest version. Otherwise, refer to the legacy documentation for enabling source code integration below.
-
-<details>
-  <summary>Legacy Source Code Integration</summary>
-
-  Change your initialization function as follows (note: we're changing this to pass just the `gitHash` value to the CDK):
-
-  ```typescript
-  async function main() {
-    // Make sure to add @datadog/datadog-ci via your package manager
-    const datadogCi = require("@datadog/datadog-ci");
-    const [, gitHash] = await datadogCi.gitMetadata.uploadGitCommitHash('{Datadog_API_Key}', '<SITE>')
-
-    const app = new cdk.App();
-    // Pass in the hash to the ExampleStack constructor
-    new ExampleStack(app, "ExampleStack", {}, gitHash);
-  }
-  ```
-
-  In your stack constructor, change to add an optional `gitHash` parameter, and call `addGitCommitMetadata()`:
-
-  ```typescript
-  export class ExampleStack extends cdk.Stack {
-    constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string) {
-      ...
-      ...
-      datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash)
-    }
-  }
-  ```
-</details>
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ export class ExampleStack extends cdk.Stack {
 ```
 
 ### Legacy Source Code Integration
-If your following dependencies are old:
+If you are using older versions of the following dependencies:
 - @datadog/datadog-ci < v2.4.0
 - datadog-cdk-constructs-v2 < v2-1.3.0
 - datadog-cdk-constructs < 0.8.4
 
-We highly encourage you to upgrade to the latest version. Otherwise, refer to the legacy documentation below.
+We highly encourage you to upgrade to the latest version. Otherwise, refer to the legacy documentation for enabling source code integration below.
 
 <details>
   <summary>Legacy Source Code Integration</summary>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>])
 datadog.addForwarderToNonLambdaLogGroups([<LOG_GROUPS>])
 ```
 
-Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/) (Typescript only), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
+Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
 
 Change your initialization function as follows (note: we're changing this to pass the `gitHash` and `gitRepoUrl` values to the CDK):
 
@@ -102,7 +102,7 @@ async function main() {
   const [gitRepoUrl, gitHash] = await datadogCi.gitMetadata.getGitCommitInfo()
 
   const app = new cdk.App();
-  // Pass in the hash to the ExampleStack constructor
+  // Pass in the hash and repo url to the ExampleStack constructor
   new ExampleStack(app, "ExampleStack", {}, gitHash, gitRepoUrl);
 }
 ```
@@ -118,6 +118,44 @@ export class ExampleStack extends cdk.Stack {
   }
 }
 ```
+
+### Legacy Source Code Integration
+If you're following dependencies are old:
+- @datadog/datadog-ci < v2.3.2
+- datadog-cdk-constructs-v2 < v2-1.3.0
+- datadog-cdk-constructs < 0.8.4
+
+We highly encourage you to upgrade to the latest version. Otherwise, refer to the legacy documentation below.
+
+<details>
+  <summary>Legacy Source Code Integration</summary>
+
+  Change your initialization function as follows (note: we're changing this to pass just the `gitHash` value to the CDK):
+
+  ```typescript
+  async function main() {
+    // Make sure to add @datadog/datadog-ci via your package manager
+    const datadogCi = require("@datadog/datadog-ci");
+    const [, gitHash] = await datadogCi.gitMetadata.uploadGitCommitHash('{Datadog_API_Key}', '<SITE>')
+
+    const app = new cdk.App();
+    // Pass in the hash to the ExampleStack constructor
+    new ExampleStack(app, "ExampleStack", {}, gitHash);
+  }
+  ```
+
+  In your stack constructor, change to add an optional `gitHash` parameter, and call `addGitCommitMetadata()`:
+
+  ```typescript
+  export class ExampleStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string) {
+      ...
+      ...
+      datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash)
+    }
+  }
+  ```
+</details>
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ datadog.addLambdaFunctions([<LAMBDA_FUNCTIONS>])
 datadog.addForwarderToNonLambdaLogGroups([<LOG_GROUPS>])
 ```
 
-Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
+Optionally, if you'd like to enable [source code integration](https://docs.datadoghq.com/integrations/guide/source-code-integration/) (Typescript only), you'll need to make a few changes to your stack setup since the AWS CDK does not support async functions.
 
 Change your initialization function as follows (note: we're changing this to pass the `gitHash` and `gitRepoUrl` values to the CDK):
 
@@ -99,7 +99,7 @@ Change your initialization function as follows (note: we're changing this to pas
 async function main() {
   // Make sure to add @datadog/datadog-ci via your package manager
   const datadogCi = require("@datadog/datadog-ci");
-  const [gitRepoUrl, gitHash] = await datadogCi.gitMetadata.getGitCommitInfo()
+  const [gitRepoUrl, gitHash] = await datadogCi.gitMetadata.getGitCommitInfo();
 
   const app = new cdk.App();
   // Pass in the hash and repo url to the ExampleStack constructor
@@ -114,14 +114,14 @@ export class ExampleStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps, gitHash?: string, gitRepoUrl?:string) {
     ...
     ...
-    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash, gitRepoUrl)
+    datadog.addGitCommitMetadata([<YOUR_FUNCTIONS>], gitHash, gitRepoUrl);
   }
 }
 ```
 
 ### Legacy Source Code Integration
-If you're following dependencies are old:
-- @datadog/datadog-ci < v2.3.2
+If your following dependencies are old:
+- @datadog/datadog-ci < v2.4.0
 - datadog-cdk-constructs-v2 < v2-1.3.0
 - datadog-cdk-constructs < 0.8.4
 

--- a/common/env.ts
+++ b/common/env.ts
@@ -20,13 +20,16 @@ export const DD_SERVICE_ENV_VAR = "DD_SERVICE";
 export const DD_VERSION_ENV_VAR = "DD_VERSION";
 export const DD_TAGS = "DD_TAGS";
 
-export function setGitCommitHashEnvironmentVariable(lambdas: any[], hash: string) {
+export function setGitCommitEnvironmentVariables(lambdas: any[], hash: string, gitRepoUrl: string | undefined) {
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lambda) => {
     if (lambda.environment[DD_TAGS] !== undefined) {
       lambda.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
     } else {
       lambda.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
+    }
+    if (gitRepoUrl) {
+      lambda.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
     }
   });
 }

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -23,7 +23,7 @@ import {
   handleSettingPropDefaults,
   redirectHandlers,
   setDDEnvVariables,
-  setGitCommitHashEnvironmentVariable,
+  setGitCommitEnvironmentVariables,
   TagKeys,
   validateProps,
 } from "./index";
@@ -96,8 +96,9 @@ export class Datadog extends cdk.Construct {
   public addGitCommitMetadata(
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
     gitCommitSha: string,
+    gitRepoUrl?: string,
   ) {
-    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha);
+    setGitCommitEnvironmentVariables(lambdaFunctions, gitCommitSha, gitRepoUrl);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {

--- a/v1/test/env.spec.ts
+++ b/v1/test/env.spec.ts
@@ -398,7 +398,7 @@ describe("DD_TAGS_ENV_VAR", () => {
           [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: "true",
           [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
           [ENABLE_DD_LOGS_ENV_VAR]: "true",
-          [DD_TAGS]: "git.commit.sha:1234",
+          [DD_TAGS]: "git.commit.sha:1234,git.repository_url:5432",
           [ENABLE_XRAY_TRACE_MERGING_ENV_VAR]: "false",
         },
       },

--- a/v1/test/env.spec.ts
+++ b/v1/test/env.spec.ts
@@ -3,8 +3,6 @@ import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
 import {
   Datadog,
-  DefaultDatadogProps,
-  transportDefaults,
   ENABLE_DD_TRACING_ENV_VAR,
   INJECT_LOG_CONTEXT_ENV_VAR,
   FLUSH_METRICS_TO_LOGS_ENV_VAR,
@@ -13,6 +11,9 @@ import {
   CAPTURE_LAMBDA_PAYLOAD_ENV_VAR,
   DD_HANDLER_ENV_VAR,
   ENABLE_XRAY_TRACE_MERGING_ENV_VAR,
+  DD_TAGS,
+  SITE_URL_ENV_VAR,
+  API_KEY_ENV_VAR,
 } from "../src/index";
 
 describe("applyEnvVariables", () => {
@@ -36,12 +37,12 @@ describe("applyEnvVariables", () => {
       Environment: {
         Variables: {
           [DD_HANDLER_ENV_VAR]: "hello.handler",
-          [FLUSH_METRICS_TO_LOGS_ENV_VAR]: transportDefaults.flushMetricsToLogs.toString(),
-          [ENABLE_DD_TRACING_ENV_VAR]: DefaultDatadogProps.enableDatadogTracing.toString(),
-          [ENABLE_XRAY_TRACE_MERGING_ENV_VAR]: DefaultDatadogProps.enableMergeXrayTraces.toString(),
-          [ENABLE_DD_LOGS_ENV_VAR]: DefaultDatadogProps.enableDatadogLogs.toString(),
-          [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: DefaultDatadogProps.captureLambdaPayload.toString(),
-          [INJECT_LOG_CONTEXT_ENV_VAR]: DefaultDatadogProps.injectLogContext.toString(),
+          [FLUSH_METRICS_TO_LOGS_ENV_VAR]: "true",
+          [ENABLE_DD_TRACING_ENV_VAR]: "true",
+          [ENABLE_XRAY_TRACE_MERGING_ENV_VAR]: "false",
+          [ENABLE_DD_LOGS_ENV_VAR]: "true",
+          [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: "false",
+          [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
         },
       },
     });
@@ -69,49 +70,13 @@ describe("applyEnvVariables", () => {
       Environment: {
         Variables: {
           ["DD_LAMBDA_HANDLER"]: "hello.handler",
-          ["DD_FLUSH_TO_LOG"]: transportDefaults.flushMetricsToLogs.toString(),
-          ["DD_TRACE_ENABLED"]: DefaultDatadogProps.enableDatadogTracing.toString(),
-          ["DD_MERGE_XRAY_TRACES"]: DefaultDatadogProps.enableMergeXrayTraces.toString(),
-          ["DD_SERVERLESS_LOGS_ENABLED"]: DefaultDatadogProps.enableDatadogLogs.toString(),
-          ["DD_CAPTURE_LAMBDA_PAYLOAD"]: DefaultDatadogProps.captureLambdaPayload.toString(),
-          ["DD_LOGS_INJECTION"]: DefaultDatadogProps.injectLogContext.toString(),
-          ["DD_LOG_LEVEL"]: EXAMPLE_LOG_LEVEL,
-        },
-      },
-    });
-  });
-
-  it("adds git hash to environment", () => {
-    const EXAMPLE_LOG_LEVEL = "debug";
-    const app = new cdk.App();
-    const stack = new cdk.Stack(app, "stack", {
-      env: {
-        region: "us-west-2",
-      },
-    });
-    const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_12_X,
-      code: lambda.Code.fromInline("test"),
-      handler: "hello.handler",
-    });
-    const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
-      logLevel: EXAMPLE_LOG_LEVEL,
-    });
-    datadogCDK.addLambdaFunctions([hello]);
-    datadogCDK.addGitCommitMetadata([hello], "1234");
-    expect(stack).toHaveResource("AWS::Lambda::Function", {
-      Environment: {
-        Variables: {
-          ["DD_LAMBDA_HANDLER"]: "hello.handler",
-          ["DD_FLUSH_TO_LOG"]: transportDefaults.flushMetricsToLogs.toString(),
-          ["DD_TRACE_ENABLED"]: DefaultDatadogProps.enableDatadogTracing.toString(),
-          ["DD_MERGE_XRAY_TRACES"]: DefaultDatadogProps.enableMergeXrayTraces.toString(),
-          ["DD_SERVERLESS_LOGS_ENABLED"]: DefaultDatadogProps.enableDatadogLogs.toString(),
-          ["DD_CAPTURE_LAMBDA_PAYLOAD"]: DefaultDatadogProps.captureLambdaPayload.toString(),
-          ["DD_LOGS_INJECTION"]: DefaultDatadogProps.injectLogContext.toString(),
-          ["DD_LOG_LEVEL"]: EXAMPLE_LOG_LEVEL,
-          ["DD_TAGS"]: "git.commit.sha:1234",
+          ["DD_FLUSH_TO_LOG"]: "true",
+          ["DD_TRACE_ENABLED"]: "true",
+          ["DD_MERGE_XRAY_TRACES"]: "false",
+          ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
+          ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",
+          ["DD_LOGS_INJECTION"]: "true",
+          ["DD_LOG_LEVEL"]: "debug",
         },
       },
     });
@@ -400,6 +365,80 @@ describe("ENABLE_DD_LOGS_ENV_VAR", () => {
           [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: "false",
           [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
           [ENABLE_DD_LOGS_ENV_VAR]: "true",
+        },
+      },
+    });
+  });
+});
+
+describe("DD_TAGS_ENV_VAR", () => {
+  it("sets git.commit.sha and git.repository_url in DD_TAGS when addGitCommitMetadata is called", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogCDK = new Datadog(stack, "Datadog", {
+      captureLambdaPayload: true,
+    });
+    datadogCDK.addLambdaFunctions([hello]);
+    datadogCDK.addGitCommitMetadata([hello], "1234", "5432");
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          [DD_HANDLER_ENV_VAR]: "hello.handler",
+          [FLUSH_METRICS_TO_LOGS_ENV_VAR]: "true",
+          [ENABLE_DD_TRACING_ENV_VAR]: "true",
+          [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: "true",
+          [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
+          [ENABLE_DD_LOGS_ENV_VAR]: "true",
+          [DD_TAGS]: "git.commit.sha:1234",
+          [ENABLE_XRAY_TRACE_MERGING_ENV_VAR]: "false",
+        },
+      },
+    });
+  });
+
+  it("doesn't overwrite DD_TAGS when addGitCommitMetadata is called", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogCDK = new Datadog(stack, "Datadog", {
+      captureLambdaPayload: true,
+      tags: "key:value",
+      // the below fields are needed or DD_TAGS won't get set
+      extensionLayerVersion: 10,
+      apiKey: "test",
+    });
+    datadogCDK.addLambdaFunctions([hello]);
+    datadogCDK.addGitCommitMetadata([hello], "1234", "5432");
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          [DD_HANDLER_ENV_VAR]: "hello.handler",
+          [FLUSH_METRICS_TO_LOGS_ENV_VAR]: "false",
+          [ENABLE_DD_TRACING_ENV_VAR]: "true",
+          [CAPTURE_LAMBDA_PAYLOAD_ENV_VAR]: "true",
+          [INJECT_LOG_CONTEXT_ENV_VAR]: "true",
+          [ENABLE_DD_LOGS_ENV_VAR]: "true",
+          [DD_TAGS]: "key:value,git.commit.sha:1234,git.repository_url:5432",
+          [ENABLE_XRAY_TRACE_MERGING_ENV_VAR]: "false",
+          [SITE_URL_ENV_VAR]: "datadoghq.com",
+          [API_KEY_ENV_VAR]: "test",
         },
       },
     });

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -25,7 +25,7 @@ import {
   DatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
-  setGitCommitHashEnvironmentVariable,
+  setGitCommitEnvironmentVariables,
   setDDEnvVariables,
 } from "./index";
 
@@ -104,8 +104,9 @@ export class Datadog extends Construct {
   public addGitCommitMetadata(
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
     gitCommitSha: string,
+    gitRepoUrl?: string,
   ) {
-    setGitCommitHashEnvironmentVariable(lambdaFunctions, gitCommitSha);
+    setGitCommitEnvironmentVariables(lambdaFunctions, gitCommitSha, gitRepoUrl);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {


### PR DESCRIPTION
### What does this PR do?

Updates the CDK to tag lambda functions with the git repo url alongside the git commit sha. Removes git metadata uploading.

Preserves the legacy way of adding SCI (metadata uploading)

the v1 and v2 env.ts unit test files were out of sync, some tests were in different orders, or missing in one test and included in the other. Slightly refactored this test file, so the tests are more in parity. Updated tests to check for git repo tagging.

- README will be updated in a future PR (after the cdk releases)

### Motivation

New Source Code Integration implementation guidelines, steering away from using git metadata upload.

### Testing Guidelines

Updated unit tests. Manually used the local version of the cdk to deploy test stacks, testing both using the legacy implementation, and this new one (requiring users to import datadog-ci >2.4.0)

### Additional Notes

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
