### PR TITLE
Enable source code integration within the CDK itself + add python support

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -30,6 +30,7 @@ export const DefaultDatadogProps = {
   enableDatadogLogs: true,
   architecture: "X86_64",
   captureLambdaPayload: false,
+  sourceCodeIntegration: true,
 };
 
 export enum TagKeys {

--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -73,6 +73,7 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
   const logLevel = props.logLevel;
   let enableDatadogLogs = props.enableDatadogLogs;
   let captureLambdaPayload = props.captureLambdaPayload;
+  let sourceCodeIntegration = props.sourceCodeIntegration;
 
   if (addLayers === undefined) {
     log.debug(`No value provided for addLayers, defaulting to ${DefaultDatadogProps.addLayers}`);
@@ -103,6 +104,10 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
     log.debug(`No value provided for captureLambdaPayload, default to ${DefaultDatadogProps.captureLambdaPayload}`);
     captureLambdaPayload = DefaultDatadogProps.captureLambdaPayload;
   }
+  if (sourceCodeIntegration === undefined) {
+    log.debug(`No value provided for sourceCodeIntegration, default to ${DefaultDatadogProps.sourceCodeIntegration}`);
+    sourceCodeIntegration = DefaultDatadogProps.sourceCodeIntegration;
+  }
 
   return {
     addLayers: addLayers,
@@ -112,5 +117,6 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
     logLevel: logLevel,
     enableDatadogLogs: enableDatadogLogs,
     captureLambdaPayload: captureLambdaPayload,
+    sourceCodeIntegration: sourceCodeIntegration,
   };
 }

--- a/common/env.ts
+++ b/common/env.ts
@@ -26,7 +26,7 @@ const URL = require("url").URL;
 
 export function setGitEnvironmentVariables(lambdas: any[]) {
   log.debug("Adding source code integration...");
-  const [hash, gitRepoUrl] = getGitData();
+  const { hash, gitRepoUrl } = getGitData();
 
   if (hash == "" || gitRepoUrl == "") return;
 
@@ -50,9 +50,9 @@ export function getGitData() {
     gitRepoUrl = execSync("git config --get remote.origin.url").toString().trim();
   } catch (e) {
     log.debug(`Failed to add source code integration. Error: ${e}`);
-    return ["", ""];
+    return { hash: "", gitRepoUrl: "" };
   }
-  return [hash, filterAndFormatGithubRemote(gitRepoUrl)];
+  return { hash, gitRepoUrl: filterAndFormatGithubRemote(gitRepoUrl) };
 }
 
 // Removes sensitive info from the given git remote url and normalizes the url prefix.

--- a/common/env.ts
+++ b/common/env.ts
@@ -20,7 +20,16 @@ export const DD_SERVICE_ENV_VAR = "DD_SERVICE";
 export const DD_VERSION_ENV_VAR = "DD_VERSION";
 export const DD_TAGS = "DD_TAGS";
 
-export function setGitCommitEnvironmentVariables(lambdas: any[], hash: string, gitRepoUrl: string | undefined) {
+const execSync = require("child_process").execSync;
+
+const URL = require("url").URL;
+
+export function setGitEnvironmentVariables(lambdas: any[]) {
+  log.debug("Adding source code integration...");
+  const [hash, gitRepoUrl] = getGitData();
+
+  if (hash == "" || gitRepoUrl == "") return;
+
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lambda) => {
     if (lambda.environment[DD_TAGS] !== undefined) {
@@ -28,10 +37,53 @@ export function setGitCommitEnvironmentVariables(lambdas: any[], hash: string, g
     } else {
       lambda.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
     }
-    if (gitRepoUrl) {
-      lambda.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
-    }
+    lambda.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
   });
+}
+
+export function getGitData() {
+  let hash: string;
+  let gitRepoUrl: string;
+
+  try {
+    hash = execSync("git rev-parse HEAD").toString().trim();
+    gitRepoUrl = execSync("git config --get remote.origin.url").toString().trim();
+  } catch (e) {
+    log.debug(`Failed to add source code integration. Error: ${e}`);
+    return ["", ""];
+  }
+  return [hash, filterAndFormatGithubRemote(gitRepoUrl)];
+}
+
+// Removes sensitive info from the given git remote url and normalizes the url prefix.
+// "git@github.com:" and "https://github.com/" prefixes will be normalized into "github.com/"
+function filterAndFormatGithubRemote(rawRemote: string) {
+  rawRemote = filterSensitiveInfoFromRepository(rawRemote);
+  if (!rawRemote) {
+    return rawRemote;
+  }
+  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
+
+  return rawRemote;
+}
+
+function filterSensitiveInfoFromRepository(repositoryUrl: string) {
+  try {
+    if (!repositoryUrl) {
+      return repositoryUrl;
+    }
+    if (repositoryUrl.startsWith("git@")) {
+      return repositoryUrl;
+    }
+    const { protocol, hostname, pathname } = new URL(repositoryUrl);
+    if (!protocol || !hostname) {
+      return repositoryUrl;
+    }
+
+    return `${protocol}//${hostname}${pathname}`;
+  } catch (e) {
+    return repositoryUrl;
+  }
 }
 
 export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: DatadogStrictProps) {

--- a/common/env.ts
+++ b/common/env.ts
@@ -41,7 +41,7 @@ export function setGitEnvironmentVariables(lambdas: any[]) {
   });
 }
 
-export function getGitData() {
+function getGitData() {
   let hash: string;
   let gitRepoUrl: string;
 

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -28,6 +28,7 @@ export interface DatadogProps {
   readonly version?: string;
   readonly tags?: string;
   readonly createForwarderPermissions?: boolean;
+  readonly sourceCodeIntegration?: boolean;
 }
 
 /*
@@ -50,6 +51,7 @@ export interface DatadogStrictProps {
   readonly apiKeySecretArn?: string;
   readonly apiKmsKey?: string;
   readonly logLevel?: string;
+  readonly sourceCodeIntegration?: boolean;
 }
 
 export interface Runtime {

--- a/v1/integration_tests/stacks/lambda-function-arm-stack.ts
+++ b/v1/integration_tests/stacks/lambda-function-arm-stack.ts
@@ -37,6 +37,7 @@ export class ExampleStack extends cdk.Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v1/integration_tests/stacks/lambda-function-stack.ts
+++ b/v1/integration_tests/stacks/lambda-function-stack.ts
@@ -35,6 +35,7 @@ export class ExampleStack extends cdk.Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v1/integration_tests/stacks/lambda-nodejs-function-stack.ts
+++ b/v1/integration_tests/stacks/lambda-nodejs-function-stack.ts
@@ -36,6 +36,7 @@ export class ExampleStack extends cdk.Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v1/integration_tests/stacks/lambda-python-function-stack.ts
+++ b/v1/integration_tests/stacks/lambda-python-function-stack.ts
@@ -37,6 +37,7 @@ export class ExampleStack extends cdk.Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -97,8 +97,15 @@ export class Datadog extends cdk.Construct {
     }
   }
 
+  // unused parameters gitCommitSha and gitRepoUrl are kept for backwards compatibility
   public addGitCommitMetadata(
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    gitCommitSha?: string,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    gitRepoUrl?: string,
   ) {
     setGitEnvironmentVariables(lambdaFunctions);
   }

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -23,7 +23,7 @@ import {
   handleSettingPropDefaults,
   redirectHandlers,
   setDDEnvVariables,
-  setGitCommitEnvironmentVariables,
+  setGitEnvironmentVariables,
   TagKeys,
   validateProps,
 } from "./index";
@@ -90,15 +90,17 @@ export class Datadog extends cdk.Construct {
       setTags(lambdaFunctions, this.props);
 
       this.transport.applyEnvVars(lambdaFunctions);
+
+      if (baseProps.sourceCodeIntegration) {
+        this.addGitCommitMetadata(lambdaFunctions);
+      }
     }
   }
 
   public addGitCommitMetadata(
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
-    gitCommitSha: string,
-    gitRepoUrl?: string,
   ) {
-    setGitCommitEnvironmentVariables(lambdaFunctions, gitCommitSha, gitRepoUrl);
+    setGitEnvironmentVariables(lambdaFunctions);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {

--- a/v1/test/index.spec.ts
+++ b/v1/test/index.spec.ts
@@ -169,6 +169,7 @@ describe("applyLayers", () => {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
       forwarderArn: "forwarder-arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -230,6 +231,7 @@ describe("applyLayers", () => {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
       forwarderArn: "forwarder-arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -277,6 +279,7 @@ describe("applyLayers", () => {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
       forwarderArn: "forwarder-arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello, hello1, hello2]);
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter");

--- a/v1/test/transport.spec.ts
+++ b/v1/test/transport.spec.ts
@@ -35,6 +35,7 @@ describe("SITE_URL_ENV_VAR", () => {
       site: "datadoghq.eu",
       flushMetricsToLogs: false,
       apiKey: "1234",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -70,6 +71,7 @@ describe("SITE_URL_ENV_VAR", () => {
       forwarderArn: "forwarder-arn",
       flushMetricsToLogs: false,
       apiKey: "1234",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -104,6 +106,7 @@ describe("SITE_URL_ENV_VAR", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       apiKey: "1234",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -139,6 +142,7 @@ describe("SITE_URL_ENV_VAR", () => {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       site: "datadoghq.eu",
       apiKey: "1234",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -174,6 +178,7 @@ describe("SITE_URL_ENV_VAR", () => {
       forwarderArn: "forwarder",
       flushMetricsToLogs: true,
       site: "datadoghq.eu",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -210,6 +215,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       apiKey: "1234",
       flushMetricsToLogs: false,
       site: "datadoghq.com",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -243,6 +249,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "forwarder-arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -276,6 +283,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       apiKey: "1234",
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -314,6 +322,7 @@ describe("API_KEY_ENV_VAR", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKey: "1234",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -352,6 +361,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       flushMetricsToLogs: true,
       site: "datadoghq.com",
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -411,6 +421,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -448,6 +459,7 @@ describe("apiKMSKeyEnvVar", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKmsKey: "5678",
+      sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {

--- a/v2/integration_tests/stacks/lambda-function-arm-stack.ts
+++ b/v2/integration_tests/stacks/lambda-function-arm-stack.ts
@@ -37,6 +37,7 @@ export class ExampleStack extends Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v2/integration_tests/stacks/lambda-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-function-stack.ts
@@ -35,6 +35,7 @@ export class ExampleStack extends Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v2/integration_tests/stacks/lambda-nodejs-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-nodejs-function-stack.ts
@@ -36,6 +36,7 @@ export class ExampleStack extends Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v2/integration_tests/stacks/lambda-python-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-python-function-stack.ts
@@ -37,6 +37,7 @@ export class ExampleStack extends Stack {
       extensionLayerVersion: 10,
       enableDatadogTracing: true,
       flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
       apiKey: "1234",
       site: "datadoghq.com",
     });

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -25,7 +25,7 @@ import {
   DatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
-  setGitCommitEnvironmentVariables,
+  setGitEnvironmentVariables,
   setDDEnvVariables,
 } from "./index";
 
@@ -98,15 +98,11 @@ export class Datadog extends Construct {
       setTags(lambdaFunctions, this.props);
 
       this.transport.applyEnvVars(lambdaFunctions);
-    }
-  }
 
-  public addGitCommitMetadata(
-    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
-    gitCommitSha: string,
-    gitRepoUrl?: string,
-  ) {
-    setGitCommitEnvironmentVariables(lambdaFunctions, gitCommitSha, gitRepoUrl);
+      if (baseProps.sourceCodeIntegration) {
+        setGitEnvironmentVariables(lambdaFunctions);
+      }
+    }
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -105,6 +105,7 @@ export class Datadog extends Construct {
     }
   }
 
+  // unused parameters gitCommitSha and gitRepoUrl are kept for backwards compatibility
   public addGitCommitMetadata(
     lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -100,9 +100,21 @@ export class Datadog extends Construct {
       this.transport.applyEnvVars(lambdaFunctions);
 
       if (baseProps.sourceCodeIntegration) {
-        setGitEnvironmentVariables(lambdaFunctions);
+        this.addGitCommitMetadata(lambdaFunctions);
       }
     }
+  }
+
+  public addGitCommitMetadata(
+    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    gitCommitSha?: string,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    gitRepoUrl?: string,
+  ) {
+    setGitEnvironmentVariables(lambdaFunctions);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

uses `execSync` from node's `child_processes` module to synchronously call `git rev-parse HEAD` and `git config --get remote.origin.url` to get the commit sha + repo url.
- Note: github repo urls are stripped of any sensitive information + are formatted. This code was copied from the datadog-ci

the `git.commit.sha` and `git.repository_url` tags are then added by default to the lambda functions.

if either of these commands fail, a warning will be printed, but deployment will continue.

users can turn off source code integration by setting the `sourceCodeIntegration` config value to false.

If users don't have the datadog github integration added, they will still need to import datadog-ci themselves and upload metadata. this will be documented in a future docs PR
- unused parameters in `addGitCommitMetadata` are kept for backwards compatibility, so previous ways of enabling source code integration don't break

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

updated unit tests to test both sourceCodeIntegration set to true and false. Manually tested by compiling the js and py packages, using them to deploy v1 & v2 python & node CDK stacks.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
