### PR TITLE
Support adding Java layers

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -11,6 +11,8 @@ export const EXTENSION_LAYER_PREFIX = "DatadogExtension";
 export const DD_ACCOUNT_ID = "464622532012";
 export const DD_GOV_ACCOUNT_ID = "002406178527";
 export const DD_HANDLER_ENV_VAR = "DD_LAMBDA_HANDLER";
+export const AWS_JAVA_WRAPPER_ENV_VAR = "AWS_LAMBDA_EXEC_WRAPPER";
+export const AWS_JAVA_WRAPPER_ENV_VAR_VALUE = "/opt/datadog_wrapper";
 export const PYTHON_HANDLER = "datadog_lambda.handler.handler";
 export const JS_HANDLER_WITH_LAYERS = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler";
 export const JS_HANDLER = "node_modules/datadog-lambda-js/dist/handler.handler";
@@ -19,6 +21,7 @@ export const SUBSCRIPTION_FILTER_PREFIX = "DatadogSubscriptionFilter";
 export enum RuntimeType {
   NODE,
   PYTHON,
+  JAVA,
   UNSUPPORTED,
 }
 
@@ -49,6 +52,8 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.7": RuntimeType.PYTHON,
   "python3.8": RuntimeType.PYTHON,
   "python3.9": RuntimeType.PYTHON,
+  "java8.al2": RuntimeType.JAVA,
+  "java11": RuntimeType.JAVA,
 };
 
 export const runtimeToLayerName: { [key: string]: string } = {
@@ -60,6 +65,8 @@ export const runtimeToLayerName: { [key: string]: string } = {
   "python3.7": "Datadog-Python37",
   "python3.8": "Datadog-Python38",
   "python3.9": "Datadog-Python39",
+  "java8.al2": "dd-trace-java",
+  "java11": "dd-trace-java",
 };
 
 export const govCloudRegions: ReadonlyArray<string> = ["us-gov-east-1", "us-gov-west-1"];

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -53,7 +53,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.8": RuntimeType.PYTHON,
   "python3.9": RuntimeType.PYTHON,
   "java8.al2": RuntimeType.JAVA,
-  java11: RuntimeType.JAVA,
+  "java11": RuntimeType.JAVA,
 };
 
 export const runtimeToLayerName: { [key: string]: string } = {
@@ -66,7 +66,7 @@ export const runtimeToLayerName: { [key: string]: string } = {
   "python3.8": "Datadog-Python38",
   "python3.9": "Datadog-Python39",
   "java8.al2": "dd-trace-java",
-  java11: "dd-trace-java",
+  "java11": "dd-trace-java",
 };
 
 export const govCloudRegions: ReadonlyArray<string> = ["us-gov-east-1", "us-gov-west-1"];

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -53,7 +53,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "python3.8": RuntimeType.PYTHON,
   "python3.9": RuntimeType.PYTHON,
   "java8.al2": RuntimeType.JAVA,
-  "java11": RuntimeType.JAVA,
+  java11: RuntimeType.JAVA,
 };
 
 export const runtimeToLayerName: { [key: string]: string } = {
@@ -66,7 +66,7 @@ export const runtimeToLayerName: { [key: string]: string } = {
   "python3.8": "Datadog-Python38",
   "python3.9": "Datadog-Python39",
   "java8.al2": "dd-trace-java",
-  "java11": "dd-trace-java",
+  java11: "dd-trace-java",
 };
 
 export const govCloudRegions: ReadonlyArray<string> = ["us-gov-east-1", "us-gov-west-1"];

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -9,6 +9,7 @@
 export interface DatadogProps {
   readonly pythonLayerVersion?: number;
   readonly nodeLayerVersion?: number;
+  readonly javaLayerVersion?: number;
   readonly extensionLayerVersion?: number;
   readonly addLayers?: boolean;
   readonly forwarderArn?: string;
@@ -43,6 +44,7 @@ export interface DatadogStrictProps {
   readonly enableMergeXrayTraces: boolean;
   readonly pythonLayerVersion?: number;
   readonly nodeLayerVersion?: number;
+  readonly javaLayerVersion?: number;
   readonly extensionLayerVersion?: number;
   readonly forwarderArn?: string;
   readonly flushMetricsToLogs?: boolean;

--- a/v1/.prettierrc
+++ b/v1/.prettierrc
@@ -1,5 +1,6 @@
 {
     "printWidth": 120,
     "trailingComma": "all",
-    "arrowParens": "always"
+    "arrowParens": "always",
+    "quoteProps": "consistent"
 }

--- a/v1/integration_tests/lambda/example-java.java
+++ b/v1/integration_tests/lambda/example-java.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class HelloLambda implements RequestHandler<Map<String, String>, String> {
+    @Override
+    public String handleRequest(final Map<String, String> event, final Context context) {
+        return null;
+    }
+}

--- a/v1/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
+++ b/v1/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
@@ -1,0 +1,516 @@
+{
+  "Resources": {
+    "HelloHandlerServiceRoleXXXXXXXX": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/HelloHandler/ServiceRole/Resource"
+      }
+    },
+    "HelloHandlerXXXXXXXX": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParametersXXXXXXXXXXXXX"
+          },
+          "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersXXXXXXXXXXXXX"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersXXXXXXXXXXXXX"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "HelloHandlerServiceRoleXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+            "DD_TRACE_ENABLED": "true",
+            "DD_MERGE_XRAY_TRACES": "false",
+            "DD_LOGS_INJECTION": "true",
+            "DD_SERVERLESS_LOGS_ENABLED": "true",
+            "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+            "DD_FLUSH_TO_LOG": "false",
+            "DD_SITE": "datadoghq.com",
+            "DD_API_KEY": "1234"
+          }
+        },
+        "Handler": "handleRequest",
+        "Layers": [
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ],
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "dd_cdk_construct",
+            "Value": "vX.XX.X"
+          }
+        ]
+      },
+      "DependsOn": [
+        "HelloHandlerServiceRoleXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/HelloHandler/Resource",
+        "aws:asset:path": "asset.XXXXXXXXXXXXX",
+        "aws:asset:original-path": "XXXXXXXXXXXXX",
+        "aws:asset:is-bundled": false,
+        "aws:asset:property": "Code"
+      }
+    },
+    "restLogGroupXXXXXXXX": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "RetentionInDays": 731
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/restLogGroup/Resource"
+      }
+    },
+    "resttestXXXXXXXX": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "rest-test"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Resource"
+      }
+    },
+    "resttestCloudWatchRoleXXXXXXXX": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/CloudWatchRole/Resource"
+      }
+    },
+    "resttestAccountXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Account",
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "resttestCloudWatchRoleXXXXXXXX",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "resttestXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Account"
+      }
+    },
+    "resttestDeploymentXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "Description": "Automatically created by the RestApi construct"
+      },
+      "DependsOn": [
+        "resttestproxyANYXXXXXXXX",
+        "resttestproxyXXXXXXXX",
+        "resttestANYXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Deployment/Resource"
+      }
+    },
+    "resttestDeploymentStageprodXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::GetAtt": [
+              "restLogGroupXXXXXXXX",
+              "Arn"
+            ]
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+        },
+        "DeploymentId": {
+          "Ref": "resttestDeploymentXXXXXXXX"
+        },
+        "StageName": "prod"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/DeploymentStage.prod/Resource"
+      }
+    },
+    "resttestproxyXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "resttestXXXXXXXX",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/Resource"
+      }
+    },
+    "resttestproxyANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/",
+              {
+                "Ref": "resttestDeploymentStageprodXXXXXXXX"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestproxyANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/test-invoke-stage/*/*"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestproxyANYXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "ANY",
+        "ResourceId": {
+          "Ref": "resttestproxyXXXXXXXX"
+        },
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "HelloHandlerXXXXXXXX",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+      }
+    },
+    "resttestANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/",
+              {
+                "Ref": "resttestDeploymentStageprodXXXXXXXX"
+              },
+              "/*/"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/test-invoke-stage/*/"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestANYXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "ANY",
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "resttestXXXXXXXX",
+            "RootResourceId"
+          ]
+        },
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "HelloHandlerXXXXXXXX",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/Resource"
+      }
+    },
+    "CDKMetadata": {
+      "Type": "AWS::CDK::Metadata",
+      "Properties": {
+        "Analytics": "vX:XXXXXX:XXXXXX"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/CDKMetadata/Default"
+      }
+    }
+  },
+  "Parameters": {
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "S3 bucket for asset XXXXXXXXXXXXX"
+    },
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "S3 key for asset XXXXXXXXXXXXX"
+    },
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "Artifact hash for asset XXXXXXXXXXXXX"
+    }
+  },
+  "Outputs": {
+    "resttestEndpointXXXXXXXX": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "resttestXXXXXXXX"
+            },
+            ".execute-api.sa-east-1.",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/",
+            {
+              "Ref": "resttestDeploymentStageprodXXXXXXXX"
+            },
+            "/"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/v1/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
+++ b/v1/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
@@ -1,0 +1,516 @@
+{
+  "Resources": {
+    "HelloHandlerServiceRoleXXXXXXXX": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/HelloHandler/ServiceRole/Resource"
+      }
+    },
+    "HelloHandlerXXXXXXXX": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParametersXXXXXXXXXXXXX"
+          },
+          "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersXXXXXXXXXXXXX"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersXXXXXXXXXXXXX"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "HelloHandlerServiceRoleXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Environment": {
+          "Variables": {
+            "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+            "DD_TRACE_ENABLED": "true",
+            "DD_MERGE_XRAY_TRACES": "false",
+            "DD_LOGS_INJECTION": "true",
+            "DD_SERVERLESS_LOGS_ENABLED": "true",
+            "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+            "DD_FLUSH_TO_LOG": "false",
+            "DD_SITE": "datadoghq.com",
+            "DD_API_KEY": "1234"
+          }
+        },
+        "Handler": "handleRequest",
+        "Layers": [
+          "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
+          "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+        ],
+        "Runtime": "java11",
+        "Tags": [
+          {
+            "Key": "dd_cdk_construct",
+            "Value": "vX.XX.X"
+          }
+        ]
+      },
+      "DependsOn": [
+        "HelloHandlerServiceRoleXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/HelloHandler/Resource",
+        "aws:asset:path": "asset.XXXXXXXXXXXXX",
+        "aws:asset:original-path": "XXXXXXXXXXXXX",
+        "aws:asset:is-bundled": false,
+        "aws:asset:property": "Code"
+      }
+    },
+    "restLogGroupXXXXXXXX": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "RetentionInDays": 731
+      },
+      "UpdateReplacePolicy": "Retain",
+      "DeletionPolicy": "Retain",
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/restLogGroup/Resource"
+      }
+    },
+    "resttestXXXXXXXX": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "Name": "rest-test"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Resource"
+      }
+    },
+    "resttestCloudWatchRoleXXXXXXXX": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "apigateway.amazonaws.com"
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+              ]
+            ]
+          }
+        ]
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/CloudWatchRole/Resource"
+      }
+    },
+    "resttestAccountXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Account",
+      "Properties": {
+        "CloudWatchRoleArn": {
+          "Fn::GetAtt": [
+            "resttestCloudWatchRoleXXXXXXXX",
+            "Arn"
+          ]
+        }
+      },
+      "DependsOn": [
+        "resttestXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Account"
+      }
+    },
+    "resttestDeploymentXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "Description": "Automatically created by the RestApi construct"
+      },
+      "DependsOn": [
+        "resttestproxyANYXXXXXXXX",
+        "resttestproxyXXXXXXXX",
+        "resttestANYXXXXXXXX"
+      ],
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Deployment/Resource"
+      }
+    },
+    "resttestDeploymentStageprodXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AccessLogSetting": {
+          "DestinationArn": {
+            "Fn::GetAtt": [
+              "restLogGroupXXXXXXXX",
+              "Arn"
+            ]
+          },
+          "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+        },
+        "DeploymentId": {
+          "Ref": "resttestDeploymentXXXXXXXX"
+        },
+        "StageName": "prod"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/DeploymentStage.prod/Resource"
+      }
+    },
+    "resttestproxyXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Resource",
+      "Properties": {
+        "ParentId": {
+          "Fn::GetAtt": [
+            "resttestXXXXXXXX",
+            "RootResourceId"
+          ]
+        },
+        "PathPart": "{proxy+}",
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/Resource"
+      }
+    },
+    "resttestproxyANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/",
+              {
+                "Ref": "resttestDeploymentStageprodXXXXXXXX"
+              },
+              "/*/*"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestproxyANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/test-invoke-stage/*/*"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestproxyANYXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "ANY",
+        "ResourceId": {
+          "Ref": "resttestproxyXXXXXXXX"
+        },
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "HelloHandlerXXXXXXXX",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+      }
+    },
+    "resttestANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/",
+              {
+                "Ref": "resttestDeploymentStageprodXXXXXXXX"
+              },
+              "/*/"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "HelloHandlerXXXXXXXX",
+            "Arn"
+          ]
+        },
+        "Principal": "apigateway.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition"
+              },
+              ":execute-api:sa-east-1:601427279990:",
+              {
+                "Ref": "resttestXXXXXXXX"
+              },
+              "/test-invoke-stage/*/"
+            ]
+          ]
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+      }
+    },
+    "resttestANYXXXXXXXX": {
+      "Type": "AWS::ApiGateway::Method",
+      "Properties": {
+        "HttpMethod": "ANY",
+        "ResourceId": {
+          "Fn::GetAtt": [
+            "resttestXXXXXXXX",
+            "RootResourceId"
+          ]
+        },
+        "RestApiId": {
+          "Ref": "resttestXXXXXXXX"
+        },
+        "AuthorizationType": "NONE",
+        "Integration": {
+          "IntegrationHttpMethod": "POST",
+          "Type": "AWS_PROXY",
+          "Uri": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition"
+                },
+                ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+                {
+                  "Fn::GetAtt": [
+                    "HelloHandlerXXXXXXXX",
+                    "Arn"
+                  ]
+                },
+                "/invocations"
+              ]
+            ]
+          }
+        }
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/Resource"
+      }
+    },
+    "CDKMetadata": {
+      "Type": "AWS::CDK::Metadata",
+      "Properties": {
+        "Analytics": "vX:XXXXXX:XXXXXX"
+      },
+      "Metadata": {
+        "aws:cdk:path": "lambda-java-function-stack/CDKMetadata/Default"
+      }
+    }
+  },
+  "Parameters": {
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "S3 bucket for asset XXXXXXXXXXXXX"
+    },
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "S3 key for asset XXXXXXXXXXXXX"
+    },
+    "AssetParametersXXXXXXXXXXXXX": {
+      "Type": "String",
+      "Description": "Artifact hash for asset XXXXXXXXXXXXX"
+    }
+  },
+  "Outputs": {
+    "resttestEndpointXXXXXXXX": {
+      "Value": {
+        "Fn::Join": [
+          "",
+          [
+            "https://",
+            {
+              "Ref": "resttestXXXXXXXX"
+            },
+            ".execute-api.sa-east-1.",
+            {
+              "Ref": "AWS::URLSuffix"
+            },
+            "/",
+            {
+              "Ref": "resttestDeploymentStageprodXXXXXXXX"
+            },
+            "/"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/v1/integration_tests/stacks/lambda-java-function-stack.ts
+++ b/v1/integration_tests/stacks/lambda-java-function-stack.ts
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+import * as lambda from "@aws-cdk/aws-lambda";
+import { LambdaRestApi, LogGroupLogDestination } from "@aws-cdk/aws-apigateway";
+import { LogGroup } from "@aws-cdk/aws-logs";
+import * as cdk from "@aws-cdk/core";
+import { Datadog } from "../../src/index";
+
+export class ExampleStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const lambdaJavaFunction = new lambda.Function(this, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      code: lambda.Code.fromAsset( __dirname + "/../lambda"),
+      handler: "handleRequest",
+    });
+
+    const restLogGroup = new LogGroup(this, "restLogGroup");
+    new LambdaRestApi(this, "rest-test", {
+      handler: lambdaJavaFunction,
+      deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(restLogGroup),
+      },
+    });
+
+    const datadogCDK = new Datadog(this, "Datadog", {
+      javaLayerVersion: 5,
+      extensionLayerVersion: 25,
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
+      apiKey: "1234",
+      site: "datadoghq.com",
+    });
+    datadogCDK.addLambdaFunctions([lambdaJavaFunction]);
+    datadogCDK.addForwarderToNonLambdaLogGroups([restLogGroup]);
+  }
+}
+
+const app = new cdk.App();
+const env = { account: "601427279990", region: "sa-east-1" };
+const stack = new ExampleStack(app, "lambda-java-function-stack", { env: env });
+console.log("Stack name: " + stack.stackName);
+app.synth();

--- a/v1/integration_tests/stacks/lambda-java-function-stack.ts
+++ b/v1/integration_tests/stacks/lambda-java-function-stack.ts
@@ -17,8 +17,8 @@ export class ExampleStack extends cdk.Stack {
     super(scope, id, props);
 
     const lambdaJavaFunction = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
-      code: lambda.Code.fromAsset( __dirname + "/../lambda"),
+      runtime: lambda.Runtime.JAVA_11,
+      code: lambda.Code.fromAsset(__dirname + "/../lambda"),
       handler: "handleRequest",
     });
 

--- a/v1/scripts/run_integration_tests.sh
+++ b/v1/scripts/run_integration_tests.sh
@@ -4,14 +4,14 @@
 # To check if new changes to the library cause changes to any snapshots:
 #   ./scripts/run_integration_tests.sh
 # To regenerate snapshots:
-#   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./scripts/run_integration_tests.sh
+#   UPDATE_SNAPSHOTS=true aws-vault exec serverless-sandbox-account-admin -- ./scripts/run_integration_tests.sh
 
 set -e
 
 # To add new tests create a new ts file in the 'integration_tests/stacks' directory, append its file name to the STACK_CONFIGS array.
 # Note: Each ts file will have its respective snapshot built in the snapshots directory, e.g. lambda-function-stack.ts
 #       will generate both snapshots/test-lambda-function-stack-snapshot.json and snapshots/correct-lambda-function-stack-snapshot.json
-STACK_CONFIGS=("lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack")
+STACK_CONFIGS=("lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack" "lambda-java-function-stack")
 
 SCRIPT_PATH=${BASH_SOURCE[0]}
 SCRIPTS_DIR=$(dirname $SCRIPT_PATH)

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -67,6 +67,7 @@ export class Datadog extends cdk.Construct {
           lambdaFunctions,
           this.props.pythonLayerVersion,
           this.props.nodeLayerVersion,
+          this.props.javaLayerVersion,
           this.props.extensionLayerVersion,
         );
       }

--- a/v1/src/layer.ts
+++ b/v1/src/layer.ts
@@ -27,6 +27,7 @@ export function applyLayers(
   lambdas: lambda.Function[],
   pythonLayerVersion?: number,
   nodeLayerVersion?: number,
+  javaLayerVersion?: number,
   extensionLayerVersion?: number,
 ) {
   // TODO: check region availability
@@ -65,6 +66,18 @@ export function applyLayers(
       }
       lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode);
       log.debug(`Using Node Lambda layer: ${lambdaLayerArn}`);
+      addLayer(lambdaLayerArn, false, scope, lam, runtime);
+    }
+
+    if (lambdaRuntimeType === RuntimeType.JAVA) {
+      if (javaLayerVersion === undefined) {
+        const errorMessage = getMissingLayerVersionErrorMsg(lam.node.id, "Java", "java");
+        log.error(errorMessage);
+        errors.push(errorMessage);
+        return;
+      }
+      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode);
+      log.debug(`Using dd-trace-java layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
 

--- a/v1/test/redirect.spec.ts
+++ b/v1/test/redirect.spec.ts
@@ -97,4 +97,26 @@ describe("redirectHandlers", () => {
       },
     });
   });
+
+  it("doesn't set env vars for function with unsupported java version", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.JAVA_8,
+      code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
+      handler: "handleRequest",
+    });
+    redirectHandlers([hello], true);
+    expect(stack).not.toHaveResource("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          [AWS_JAVA_WRAPPER_ENV_VAR]: AWS_JAVA_WRAPPER_ENV_VAR_VALUE,
+        },
+      },
+    });
+  });
 });

--- a/v1/test/redirect.spec.ts
+++ b/v1/test/redirect.spec.ts
@@ -1,7 +1,15 @@
 import * as lambda from "@aws-cdk/aws-lambda";
 import * as cdk from "@aws-cdk/core";
 import "@aws-cdk/assert/jest";
-import { redirectHandlers, JS_HANDLER_WITH_LAYERS, JS_HANDLER, PYTHON_HANDLER, DD_HANDLER_ENV_VAR } from "../src/index";
+import {
+  redirectHandlers,
+  JS_HANDLER_WITH_LAYERS,
+  JS_HANDLER,
+  PYTHON_HANDLER,
+  DD_HANDLER_ENV_VAR,
+  AWS_JAVA_WRAPPER_ENV_VAR,
+  AWS_JAVA_WRAPPER_ENV_VAR_VALUE,
+} from "../src/index";
 
 describe("redirectHandlers", () => {
   it("redirects js handler correctly when addLayers is true", () => {
@@ -60,6 +68,31 @@ describe("redirectHandlers", () => {
       Environment: {
         Variables: {
           [DD_HANDLER_ENV_VAR]: "hello.handler",
+        },
+      },
+    });
+  });
+
+  it("sets correct env var for java functions", () => {
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.JAVA_11,
+      code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
+      handler: "handleRequest",
+    });
+    redirectHandlers([hello], true);
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Handler: "handleRequest",
+    });
+    expect(stack).toHaveResource("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          [AWS_JAVA_WRAPPER_ENV_VAR]: AWS_JAVA_WRAPPER_ENV_VAR_VALUE,
         },
       },
     });

--- a/v2/.prettierrc
+++ b/v2/.prettierrc
@@ -1,5 +1,6 @@
 {
     "printWidth": 120,
     "trailingComma": "all",
-    "arrowParens": "always"
+    "arrowParens": "always",
+    "quoteProps": "consistent"
 }

--- a/v2/integration_tests/lambda/example-java.java
+++ b/v2/integration_tests/lambda/example-java.java
@@ -1,0 +1,10 @@
+import java.util.Map;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+
+public class HelloLambda implements RequestHandler<Map<String, String>, String> {
+    @Override
+    public String handleRequest(final Map<String, String> event, final Context context) {
+        return null;
+    }
+}

--- a/v2/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
@@ -1,0 +1,508 @@
+{
+ "Resources": {
+  "HelloHandlerServiceRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandlerXXXXXXXX": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
+     "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Environment": {
+     "Variables": {
+      "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+      "DD_TRACE_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_LOGS_INJECTION": "true",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_FLUSH_TO_LOG": "false",
+      "DD_SITE": "datadoghq.com",
+      "DD_API_KEY": "1234"
+     }
+    },
+    "Handler": "handleRequest",
+    "Layers": [
+     "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+    ],
+    "Runtime": "java11",
+    "Tags": [
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     }
+    ]
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRoleXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/HelloHandler/Resource",
+    "aws:asset:path": "asset.XXXXXXXXXXXXX",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "restLogGroupXXXXXXXX": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 731
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/restLogGroup/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "rest-test"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Resource"
+   }
+  },
+  "resttestCloudWatchRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/CloudWatchRole/Resource"
+   }
+  },
+  "resttestAccountXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "resttestCloudWatchRoleXXXXXXXX",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "resttestXXXXXXXX"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Account"
+   }
+  },
+  "resttestDeploymentXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "Description": "Automatically created by the RestApi construct"
+   },
+   "DependsOn": [
+    "resttestproxyANYXXXXXXXX",
+    "resttestproxyXXXXXXXX",
+    "resttestANYXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Deployment/Resource"
+   }
+  },
+  "resttestDeploymentStageprodXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AccessLogSetting": {
+     "DestinationArn": {
+      "Fn::GetAtt": [
+       "restLogGroupXXXXXXXX",
+       "Arn"
+      ]
+     },
+     "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+    },
+    "DeploymentId": {
+     "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "resttestAccountXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/DeploymentStage.prod/Resource"
+   }
+  },
+  "resttestproxyXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/Resource"
+   }
+  },
+  "resttestproxyANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "resttestANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "vX:XXXXXX:XXXXXX"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "resttestEndpointXXXXXXXX": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "resttestXXXXXXXX"
+      },
+      ".execute-api.sa-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "resttestDeploymentStageprodXXXXXXXX"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/v2/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
@@ -1,0 +1,508 @@
+{
+ "Resources": {
+  "HelloHandlerServiceRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandlerXXXXXXXX": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
+     "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
+    },
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Environment": {
+     "Variables": {
+      "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
+      "DD_TRACE_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_LOGS_INJECTION": "true",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_FLUSH_TO_LOG": "false",
+      "DD_SITE": "datadoghq.com",
+      "DD_API_KEY": "1234"
+     }
+    },
+    "Handler": "handleRequest",
+    "Layers": [
+     "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+    ],
+    "Runtime": "java11",
+    "Tags": [
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     }
+    ]
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRoleXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/HelloHandler/Resource",
+    "aws:asset:path": "asset.XXXXXXXXXXXXX",
+    "aws:asset:is-bundled": false,
+    "aws:asset:property": "Code"
+   }
+  },
+  "restLogGroupXXXXXXXX": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 731
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/restLogGroup/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "rest-test"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Resource"
+   }
+  },
+  "resttestCloudWatchRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/CloudWatchRole/Resource"
+   }
+  },
+  "resttestAccountXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "resttestCloudWatchRoleXXXXXXXX",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "resttestXXXXXXXX"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Account"
+   }
+  },
+  "resttestDeploymentXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "Description": "Automatically created by the RestApi construct"
+   },
+   "DependsOn": [
+    "resttestproxyANYXXXXXXXX",
+    "resttestproxyXXXXXXXX",
+    "resttestANYXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Deployment/Resource"
+   }
+  },
+  "resttestDeploymentStageprodXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AccessLogSetting": {
+     "DestinationArn": {
+      "Fn::GetAtt": [
+       "restLogGroupXXXXXXXX",
+       "Arn"
+      ]
+     },
+     "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+    },
+    "DeploymentId": {
+     "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "resttestAccountXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/DeploymentStage.prod/Resource"
+   }
+  },
+  "resttestproxyXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/Resource"
+   }
+  },
+  "resttestproxyANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "resttestANYApiPermissionlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYApiPermissionTestlambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdajavafunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "HttpMethod": "ANY",
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "AuthorizationType": "NONE",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/rest-test/Default/ANY/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "vX:XXXXXX:XXXXXX"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-java-function-stack/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "resttestEndpointXXXXXXXX": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "resttestXXXXXXXX"
+      },
+      ".execute-api.sa-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "resttestDeploymentStageprodXXXXXXXX"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/v2/integration_tests/stacks/lambda-java-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-java-function-stack.ts
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Datadog } from "../../src/index";
+
+export class ExampleStack extends Stack {
+  constructor(scope: App, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const lambdaJavaFunction = new lambda.Function(this, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      code: lambda.Code.fromAsset(__dirname + "/../lambda"),
+      handler: "handleRequest",
+    });
+
+    const restLogGroup = new LogGroup(this, "restLogGroup");
+    new LambdaRestApi(this, "rest-test", {
+      handler: lambdaJavaFunction,
+      deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(restLogGroup),
+      },
+    });
+
+    const datadogCDK = new Datadog(this, "Datadog", {
+      javaLayerVersion: 5,
+      extensionLayerVersion: 25,
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
+      apiKey: "1234",
+      site: "datadoghq.com",
+    });
+    datadogCDK.addLambdaFunctions([lambdaJavaFunction]);
+    datadogCDK.addForwarderToNonLambdaLogGroups([restLogGroup]);
+  }
+}
+
+const app = new App();
+const env = { account: "601427279990", region: "sa-east-1" };
+const stack = new ExampleStack(app, "lambda-java-function-stack", { env: env });
+console.log("Stack name: " + stack.stackName);
+app.synth();

--- a/v2/integration_tests/stacks/lambda-java-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-java-function-stack.ts
@@ -17,7 +17,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaJavaFunction = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.JAVA_11,
       code: lambda.Code.fromAsset(__dirname + "/../lambda"),
       handler: "handleRequest",
     });

--- a/v2/scripts/run_integration_tests.sh
+++ b/v2/scripts/run_integration_tests.sh
@@ -4,14 +4,14 @@
 # To check if new changes to the library cause changes to any snapshots:
 #   ./scripts/run_integration_tests.sh
 # To regenerate snapshots:
-#   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./scripts/run_integration_tests.sh
+#   UPDATE_SNAPSHOTS=true aws-vault exec serverless-sandbox-account-admin -- ./scripts/run_integration_tests.sh
 
 set -e
 
 # To add new tests create a new ts file in the 'integration_tests/stacks' directory, append its file name to the STACK_CONFIGS array.
 # Note: Each ts file will have its respective snapshot built in the snapshots directory, e.g. lambda-function-stack.ts
 #       will generate both snapshots/test-lambda-function-stack-snapshot.json and snapshots/correct-lambda-function-stack-snapshot.json
-STACK_CONFIGS=("lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack")
+STACK_CONFIGS=("lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack" "lambda-java-function-stack")
 
 SCRIPT_PATH=${BASH_SOURCE[0]}
 SCRIPTS_DIR=$(dirname $SCRIPT_PATH)

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -70,6 +70,7 @@ export class Datadog extends Construct {
           lambdaFunctions,
           this.props.pythonLayerVersion,
           this.props.nodeLayerVersion,
+          this.props.javaLayerVersion,
           this.props.extensionLayerVersion,
         );
       }

--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -27,6 +27,7 @@ export function applyLayers(
   lambdas: lambda.Function[],
   pythonLayerVersion?: number,
   nodeLayerVersion?: number,
+  javaLayerVersion?: number,
   extensionLayerVersion?: number,
 ) {
   // TODO: check region availability
@@ -65,6 +66,18 @@ export function applyLayers(
       }
       lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode);
       log.debug(`Using Node Lambda layer: ${lambdaLayerArn}`);
+      addLayer(lambdaLayerArn, false, scope, lam, runtime);
+    }
+
+    if (lambdaRuntimeType === RuntimeType.JAVA) {
+      if (javaLayerVersion === undefined) {
+        const errorMessage = getMissingLayerVersionErrorMsg(lam.node.id, "Java", "java");
+        log.error(errorMessage);
+        errors.push(errorMessage);
+        return;
+      }
+      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode);
+      log.debug(`Using dd-trace-java layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
 

--- a/v2/test/redirect.spec.ts
+++ b/v2/test/redirect.spec.ts
@@ -78,10 +78,10 @@ describe("redirectHandlers", () => {
       handler: "handleRequest",
     });
     redirectHandlers([hello], true);
-    expect(stack).toHaveResource("AWS::Lambda::Function", {
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: "handleRequest",
     });
-    expect(stack).toHaveResource("AWS::Lambda::Function", {
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Environment: {
         Variables: {
           [AWS_JAVA_WRAPPER_ENV_VAR]: AWS_JAVA_WRAPPER_ENV_VAR_VALUE,

--- a/v2/test/redirect.spec.ts
+++ b/v2/test/redirect.spec.ts
@@ -1,7 +1,15 @@
 import { App, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { redirectHandlers, JS_HANDLER_WITH_LAYERS, JS_HANDLER, PYTHON_HANDLER, DD_HANDLER_ENV_VAR, AWS_JAVA_WRAPPER_ENV_VAR, AWS_JAVA_WRAPPER_ENV_VAR_VALUE} from "../src/index";
+import {
+  redirectHandlers,
+  JS_HANDLER_WITH_LAYERS,
+  JS_HANDLER,
+  PYTHON_HANDLER,
+  DD_HANDLER_ENV_VAR,
+  AWS_JAVA_WRAPPER_ENV_VAR,
+  AWS_JAVA_WRAPPER_ENV_VAR_VALUE,
+} from "../src/index";
 
 describe("redirectHandlers", () => {
   it("redirects js handler correctly when addLayers is true", () => {
@@ -88,5 +96,31 @@ describe("redirectHandlers", () => {
         },
       },
     });
+  });
+
+  it("doesn't set env vars for function with unsupported java version", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.JAVA_8,
+      code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
+      handler: "handleRequest",
+    });
+    redirectHandlers([hello], true);
+    Template.fromStack(stack).resourcePropertiesCountIs(
+      "AWS::Lambda::Function",
+      {
+        Environment: {
+          Variables: {
+            [AWS_JAVA_WRAPPER_ENV_VAR]: AWS_JAVA_WRAPPER_ENV_VAR_VALUE,
+          },
+        },
+      },
+      0,
+    );
   });
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support (cdk v1 & cdk v2) for adding the java tracing layer to lambda functions instrumented with the CDK.

Specifically, the `dd-trace-java` lambda layer will be added and the `AWS_LAMBDA_EXEC_WRAPPER=/opt/datadog_wrapper` env var will be set.

Only supports java8 corretto & java11

### Motivation

addresses [this opened issue/feature request](https://github.com/DataDog/datadog-cdk-constructs/issues/153).

### Testing Guidelines

Updated unit tests & integration tests.
I also built the cdk and manually tested both V1 & V2 on Python AND Typescript stacks.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
