### PR TITLE
feat: add `DD_APM_FLUSH_DEADLINE_MILLISECONDS` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ _Note_: The descriptions use the npm package parameters, but they also apply to 
 | `enableProfiling`             | `enable_profiling` | Enable the Datadog Continuous Profiler with `true`. Supported in Beta for NodeJS and Python. Defaults to `false`. |
 | `encodeAuthorizerContext`     |`encode_authorizer_context` | When set to `true` for Lambda authorizers, the tracing context will be encoded into the response for propagation. Supported for NodeJS and Python. Defaults to `true`. |
 | `decodeAuthorizerContext`     |`decode_authorizer_context` | When set to `true` for Lambdas that are authorized via Lambda authorizers, it will parse and use the encoded tracing context (if found). Supported for NodeJS and Python. Defaults to `true`.                         |
+| `apmFlushDeadline` | Used to determine when to submit spans before a timeout occurs, in milliseconds. When the remaining time in an AWS Lambda invocation is less than the value set. The tracer will attempt to submit the current active spans and all finished spans. Supported for NodeJS and Python. Defaults to `100` milliseconds. |
 
 **Note**: Using the parameters above may override corresponding function level `DD_XXX` environment variables.
 ### Tracing

--- a/common/env.ts
+++ b/common/env.ts
@@ -25,6 +25,7 @@ export const DD_COLD_START_TRACE_SKIP_LIB = "DD_COLD_START_TRACE_SKIP_LIB";
 export const DD_PROFILING_ENABLED = "DD_PROFILING_ENABLED";
 export const DD_ENCODE_AUTHORIZER_CONTEXT = "DD_ENCODE_AUTHORIZER_CONTEXT";
 export const DD_DECODE_AUTHORIZER_CONTEXT = "DD_DECODE_AUTHORIZER_CONTEXT";
+export const DD_APM_FLUSH_DEADLINE_MILLISECONDS = "DD_APM_FLUSH_DEADLINE_MILLISECONDS";
 
 const execSync = require("child_process").execSync;
 
@@ -139,6 +140,9 @@ export function setDDEnvVariables(lambdas: ILambdaFunction[], props: DatadogProp
     }
     if (props.decodeAuthorizerContext !== undefined) {
       lam.addEnvironment(DD_DECODE_AUTHORIZER_CONTEXT, props.decodeAuthorizerContext.toString().toLowerCase());
+    }
+    if (props.apmFlushDeadline !== undefined) {
+      lam.addEnvironment(DD_APM_FLUSH_DEADLINE_MILLISECONDS, props.apmFlushDeadline.toString().toLowerCase());
     }
   });
 }

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -36,6 +36,7 @@ export interface DatadogProps {
   readonly enableProfiling?: boolean;
   readonly encodeAuthorizerContext?: boolean;
   readonly decodeAuthorizerContext?: boolean;
+  readonly apmFlushDeadline?: string | number;
 }
 
 /*

--- a/v1/test/env.spec.ts
+++ b/v1/test/env.spec.ts
@@ -114,6 +114,7 @@ describe("setDDEnvVariables", () => {
       enableProfiling: true,
       encodeAuthorizerContext: false,
       decodeAuthorizerContext: false,
+      apmFlushDeadline: 20,
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -134,6 +135,7 @@ describe("setDDEnvVariables", () => {
           ["DD_PROFILING_ENABLED"]: "true",
           ["DD_ENCODE_AUTHORIZER_CONTEXT"]: "false",
           ["DD_DECODE_AUTHORIZER_CONTEXT"]: "false",
+          ["DD_APM_FLUSH_DEADLINE_MILLISECONDS"]: "20",
         },
       },
     });

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -112,6 +112,7 @@ describe("setDDEnvVariables", () => {
       enableProfiling: true,
       encodeAuthorizerContext: false,
       decodeAuthorizerContext: false,
+      apmFlushDeadline: "20",
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -131,6 +132,7 @@ describe("setDDEnvVariables", () => {
           ["DD_PROFILING_ENABLED"]: "true",
           ["DD_ENCODE_AUTHORIZER_CONTEXT"]: "false",
           ["DD_DECODE_AUTHORIZER_CONTEXT"]: "false",
+          ["DD_APM_FLUSH_DEADLINE_MILLISECONDS"]: "20",
         },
       },
     });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds the field `apmFlushDeadline` which sets `DD_APM_FLUSH_DEADLINE_MILLISECONDS`.
This field allows users to determine when to submit spans before a timeout.

### Motivation

Configure custom deadline before a timeout. Which is available in both the tracers for Python and NodeJS.

### Testing Guidelines

Added unit tests.


### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [x] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
