### PR TITLE
Add link to GH tags page in release output

### DIFF
--- a/v2/scripts/publish_prod.sh
+++ b/v2/scripts/publish_prod.sh
@@ -125,4 +125,4 @@ python3 -m twine upload -u __token__ ./dist/python/*
 echo 'Pushing updates to github'
 git push origin main
 git push origin "refs/tags/v2-$VERSION"
-echo 'Please add release notes in GitHub!'
+echo 'Please create a release with notes from the new tag at GitHub https://github.com/DataDog/datadog-cdk-constructs/tags'


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Just adds a link to the release script output

### Motivation
Easier to click the link

### Testing Guidelines
https://github.com/DataDog/datadog-cdk-constructs/tags

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
