### PR TITLE
Automatically grant functions read access to a given aws secret

### DIFF
--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -8,9 +8,9 @@
 
 import log from "loglevel";
 import { DefaultDatadogProps } from "./constants";
-import { DatadogProps, DatadogStrictProps } from "./interfaces";
+import { IDatadogProps, DatadogStrictProps } from "./interfaces";
 
-export function validateProps(props: DatadogProps) {
+export function validateProps(props: IDatadogProps) {
   log.debug("Validating props...");
 
   checkForMultipleApiKeys(props);
@@ -49,7 +49,7 @@ export function validateProps(props: DatadogProps) {
   }
 }
 
-export function checkForMultipleApiKeys(props: DatadogProps) {
+export function checkForMultipleApiKeys(props: IDatadogProps) {
   let multipleApiKeysMessage;
   if (props.apiKey !== undefined && props.apiKmsKey !== undefined && props.apiKeySecretArn !== undefined) {
     multipleApiKeysMessage = "`apiKey`, `apiKmsKey`, and `apiKeySecretArn`";
@@ -66,7 +66,7 @@ export function checkForMultipleApiKeys(props: DatadogProps) {
   }
 }
 
-export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictProps {
+export function handleSettingPropDefaults(props: IDatadogProps): DatadogStrictProps {
   let addLayers = props.addLayers;
   let enableDatadogTracing = props.enableDatadogTracing;
   let enableMergeXrayTraces = props.enableMergeXrayTraces;

--- a/common/env.ts
+++ b/common/env.ts
@@ -7,7 +7,7 @@
  */
 
 import log from "loglevel";
-import { DatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
+import { IDatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
 export const ENABLE_XRAY_TRACE_MERGING_ENV_VAR = "DD_MERGE_XRAY_TRACES";
@@ -107,7 +107,7 @@ export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: Datadog
   });
 }
 
-export function setDDEnvVariables(lambdas: ILambdaFunction[], props: DatadogProps) {
+export function setDDEnvVariables(lambdas: ILambdaFunction[], props: IDatadogProps) {
   lambdas.forEach((lam) => {
     if (props.extensionLayerVersion) {
       if (props.env) {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -6,7 +6,7 @@
  * Copyright 2021 Datadog, Inc.
  */
 
-export interface DatadogProps {
+export interface IDatadogProps {
   readonly pythonLayerVersion?: number;
   readonly nodeLayerVersion?: number;
   readonly javaLayerVersion?: number;
@@ -16,7 +16,7 @@ export interface DatadogProps {
   readonly flushMetricsToLogs?: boolean;
   readonly site?: string;
   readonly apiKey?: string;
-  readonly apiKeySecretArn?: string;
+  apiKeySecretArn?: string;
   readonly apiKmsKey?: string;
   readonly enableDatadogTracing?: boolean;
   readonly enableMergeXrayTraces?: boolean;

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -18,7 +18,7 @@ import {
   addForwarderToLogGroups,
   applyEnvVariables,
   applyLayers,
-  DatadogProps,
+  IDatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
   redirectHandlers,
@@ -32,9 +32,9 @@ const versionJson = require("../version.json");
 
 export class Datadog extends cdk.Construct {
   scope: cdk.Construct;
-  props: DatadogProps;
+  props: IDatadogProps;
   transport: Transport;
-  constructor(scope: cdk.Construct, id: string, props: DatadogProps) {
+  constructor(scope: cdk.Construct, id: string, props: IDatadogProps) {
     if (process.env.DD_CONSTRUCT_DEBUG_LOGS?.toLowerCase() == "true") {
       log.setLevel("debug");
     }
@@ -129,7 +129,7 @@ export function addCdkConstructVersionTag(lambdaFunctions: lambda.Function[]) {
   });
 }
 
-function setTags(lambdaFunctions: lambda.Function[], props: DatadogProps) {
+function setTags(lambdaFunctions: lambda.Function[], props: IDatadogProps) {
   log.debug(`Adding datadog tags`);
   lambdaFunctions.forEach((functionName) => {
     if (props.forwarderArn) {

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -507,8 +507,8 @@ describe("apiKeySecret", () => {
     });
     datadogCdk.addLambdaFunctions([hello]);
     expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn-from-isecret");
-  })
-})
+  });
+});
 
 describe("redirectHandler", () => {
   it("doesn't redirect handler when explicitly set to `false`", () => {

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -467,7 +467,6 @@ describe("apiKeySecret", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-
     const secret: typeof ISecret = {
       secretArn: "dummy-arn",
       grantRead() {
@@ -482,9 +481,8 @@ describe("apiKeySecret", () => {
       flushMetricsToLogs: false,
     });
     datadogCdk.addLambdaFunctions([hello]);
-
     expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn");
-  }),
+  });
   it("overrides apiKeySecretArn", () => {
     const app = new App();
     const stack = new Stack(app, "stack");
@@ -493,7 +491,6 @@ describe("apiKeySecret", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-
     const secret: typeof ISecret = {
       secretArn: "dummy-arn-from-isecret",
       grantRead() {
@@ -509,7 +506,6 @@ describe("apiKeySecret", () => {
       flushMetricsToLogs: false,
     });
     datadogCdk.addLambdaFunctions([hello]);
-
     expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn-from-isecret");
   });
 });

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -3,6 +3,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { addCdkConstructVersionTag, checkForMultipleApiKeys, Datadog } from "../src/index";
+const { ISecret } = require("aws-cdk-lib/aws-secretsmanager");
 const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
 const NODE_LAYER_VERSION = 1;
@@ -67,6 +68,43 @@ describe("validateProps", () => {
         enableDatadogTracing: false,
         flushMetricsToLogs: false,
         site: `${datadogSite}`,
+      });
+      datadogCdk.addLambdaFunctions([hello]);
+    } catch (e) {
+      threwError = true;
+      if (e instanceof Error) {
+        thrownError = e;
+      }
+    }
+    expect(threwError).toBe(false);
+    expect(thrownError?.message).toEqual(undefined);
+  });
+
+  it("doesn't throw an error if an apiKeySecret is set", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+
+    const secret: typeof ISecret = {
+      secretArn: "dummy-arn",
+      grantRead() {
+        return;
+      },
+    };
+
+    let threwError = false;
+    let thrownError: Error | undefined;
+    try {
+      const datadogCdk = new Datadog(stack, "Datadog", {
+        nodeLayerVersion: NODE_LAYER_VERSION,
+        extensionLayerVersion: EXTENSION_LAYER_VERSION,
+        apiKeySecret: secret,
+        enableDatadogTracing: false,
+        flushMetricsToLogs: false,
       });
       datadogCdk.addLambdaFunctions([hello]);
     } catch (e) {
@@ -417,5 +455,61 @@ describe("setTags", () => {
         },
       ],
     });
+  });
+});
+
+describe("apiKeySecret", () => {
+  it("sets apiKeySecretArn", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+
+    const secret: typeof ISecret = {
+      secretArn: "dummy-arn",
+      grantRead() {
+        return;
+      },
+    };
+    const datadogCdk = new Datadog(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKeySecret: secret,
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+    });
+    datadogCdk.addLambdaFunctions([hello]);
+
+    expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn");
+  }),
+  it("overrides apiKeySecretArn", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+
+    const secret: typeof ISecret = {
+      secretArn: "dummy-arn-from-isecret",
+      grantRead() {
+        return;
+      },
+    };
+    const datadogCdk = new Datadog(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKeySecret: secret,
+      apiKeySecretArn: "dummy-arn",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+    });
+    datadogCdk.addLambdaFunctions([hello]);
+
+    expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn-from-isecret");
   });
 });


### PR DESCRIPTION
Lets users do the following (from [this issue](https://github.com/DataDog/datadog-cdk-constructs/issues/174)):

Instead of passing in an `apiKeySecretArn` or `apiKey`, users can create a Secret object and pass that in to Datadog:
```
const secret = Secret.fromSecretPartialArn(this, 'DatadogApiKeySecret', 'arn:aws:secretsmanager:us-west-123123123:secret:DATADOG_API_KEY');

const datadog = new Datadog(scope, 'Datadog', {
  nodeLayerVersion: 91,
  extensionLayerVersion: 43,
  addLayers: true,
  ...
  apiKeySecret: secret
  ...
});
```
- the `Secret.fromSecretPartialArn` is imported from `aws-cdk-lib/aws-secretsmanager`

With this secret object, we can grant lambda functions read access to the secret, so users don't have to manually grant secret read access to the lambda execution role.

Under the hood, we set `apiKeySecretArn` with the value fetched from the secret object, if both `apiKeySecretArn` and `apiKeySecret` are declared, `apiKeySecretArn` will be overrided.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

### Motivation

https://github.com/DataDog/datadog-cdk-constructs/issues/174

### Testing Guidelines

added unit tests & manually tested

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
