### PR TITLE
Fix: auto grant secret read permissions python package bug

### DIFF
--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -10,7 +10,7 @@ import log from "loglevel";
 import { DefaultDatadogProps } from "./constants";
 import { IDatadogProps, DatadogStrictProps } from "./interfaces";
 
-export function validateProps(props: IDatadogProps, apiKeyArnOverride?: boolean) {
+export function validateProps(props: IDatadogProps, apiKeyArnOverride = false) {
   log.debug("Validating props...");
 
   checkForMultipleApiKeys(props, apiKeyArnOverride);
@@ -55,7 +55,7 @@ export function validateProps(props: IDatadogProps, apiKeyArnOverride?: boolean)
   }
 }
 
-export function checkForMultipleApiKeys(props: IDatadogProps, apiKeyArnOverride?: boolean) {
+export function checkForMultipleApiKeys(props: IDatadogProps, apiKeyArnOverride = false) {
   let multipleApiKeysMessage;
   const apiKeyArnOrOverride = props.apiKeySecretArn !== undefined || apiKeyArnOverride;
   if (props.apiKey !== undefined && props.apiKmsKey !== undefined && apiKeyArnOrOverride) {

--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -10,10 +10,10 @@ import log from "loglevel";
 import { DefaultDatadogProps } from "./constants";
 import { IDatadogProps, DatadogStrictProps } from "./interfaces";
 
-export function validateProps(props: IDatadogProps) {
+export function validateProps(props: IDatadogProps, apiKeyArnOverride?: boolean) {
   log.debug("Validating props...");
 
-  checkForMultipleApiKeys(props);
+  checkForMultipleApiKeys(props, apiKeyArnOverride);
   const siteList: string[] = [
     "datadoghq.com",
     "datadoghq.eu",
@@ -36,28 +36,35 @@ export function validateProps(props: IDatadogProps) {
     props.apiKey === undefined &&
     props.apiKmsKey === undefined &&
     props.apiKeySecretArn === undefined &&
-    props.flushMetricsToLogs === false
+    props.flushMetricsToLogs === false &&
+    !apiKeyArnOverride
   ) {
     throw new Error(
       "When `flushMetricsToLogs` is false, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.",
     );
   }
   if (props.extensionLayerVersion !== undefined) {
-    if (props.apiKey === undefined && props.apiKeySecretArn === undefined && props.apiKmsKey === undefined) {
+    if (
+      props.apiKey === undefined &&
+      props.apiKeySecretArn === undefined &&
+      props.apiKmsKey === undefined &&
+      !apiKeyArnOverride
+    ) {
       throw new Error("When `extensionLayer` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");
     }
   }
 }
 
-export function checkForMultipleApiKeys(props: IDatadogProps) {
+export function checkForMultipleApiKeys(props: IDatadogProps, apiKeyArnOverride?: boolean) {
   let multipleApiKeysMessage;
-  if (props.apiKey !== undefined && props.apiKmsKey !== undefined && props.apiKeySecretArn !== undefined) {
+  const apiKeyArnOrOverride = props.apiKeySecretArn !== undefined || apiKeyArnOverride;
+  if (props.apiKey !== undefined && props.apiKmsKey !== undefined && apiKeyArnOrOverride) {
     multipleApiKeysMessage = "`apiKey`, `apiKmsKey`, and `apiKeySecretArn`";
   } else if (props.apiKey !== undefined && props.apiKmsKey !== undefined) {
     multipleApiKeysMessage = "`apiKey` and `apiKmsKey`";
-  } else if (props.apiKey !== undefined && props.apiKeySecretArn !== undefined) {
+  } else if (props.apiKey !== undefined && apiKeyArnOrOverride) {
     multipleApiKeysMessage = "`apiKey` and `apiKeySecretArn`";
-  } else if (props.apiKmsKey !== undefined && props.apiKeySecretArn !== undefined) {
+  } else if (props.apiKmsKey !== undefined && apiKeyArnOrOverride) {
     multipleApiKeysMessage = "`apiKmsKey` and `apiKeySecretArn`";
   }
 

--- a/v2/src/index.ts
+++ b/v2/src/index.ts
@@ -10,6 +10,7 @@ export * from "./datadog";
 export * from "./layer";
 export * from "./common/redirect";
 export * from "./forwarder";
+export * from "./interfacesV2";
 export * from "./common/env";
 export * from "./common/transport";
 export * from "./common/constants";

--- a/v2/src/interfacesV2.ts
+++ b/v2/src/interfacesV2.ts
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+import * as secrets from "aws-cdk-lib/aws-secretsmanager";
+
+export interface DatadogPropsV2 {
+  readonly pythonLayerVersion?: number;
+  readonly nodeLayerVersion?: number;
+  readonly javaLayerVersion?: number;
+  readonly extensionLayerVersion?: number;
+  readonly addLayers?: boolean;
+  readonly forwarderArn?: string;
+  readonly flushMetricsToLogs?: boolean;
+  readonly site?: string;
+  readonly apiKey?: string;
+  readonly apiKeySecretArn?: string;
+  readonly apiKeySecret?: secrets.ISecret;
+  readonly apiKmsKey?: string;
+  readonly enableDatadogTracing?: boolean;
+  readonly enableMergeXrayTraces?: boolean;
+  readonly injectLogContext?: boolean;
+  readonly logLevel?: string;
+  readonly enableDatadogLogs?: boolean;
+  readonly captureLambdaPayload?: boolean;
+  readonly env?: string;
+  readonly service?: string;
+  readonly version?: string;
+  readonly tags?: string;
+  readonly createForwarderPermissions?: boolean;
+  readonly sourceCodeIntegration?: boolean;
+  readonly enableColdStartTracing?: boolean;
+  readonly minColdStartTraceDuration?: number;
+  readonly coldStartTraceSkipLibs?: string;
+  readonly enableProfiling?: boolean;
+  readonly encodeAuthorizerContext?: boolean;
+  readonly decodeAuthorizerContext?: boolean;
+  readonly apmFlushDeadline?: string | number;
+  readonly redirectHandler?: boolean;
+}

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -481,7 +481,7 @@ describe("apiKeySecret", () => {
       flushMetricsToLogs: false,
     });
     datadogCdk.addLambdaFunctions([hello]);
-    expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn");
+    expect(datadogCdk.transport.apiKeySecretArn).toEqual("dummy-arn");
   });
   it("overrides apiKeySecretArn", () => {
     const app = new App();
@@ -506,7 +506,7 @@ describe("apiKeySecret", () => {
       flushMetricsToLogs: false,
     });
     datadogCdk.addLambdaFunctions([hello]);
-    expect(datadogCdk.props.apiKeySecretArn).toEqual("dummy-arn-from-isecret");
+    expect(datadogCdk.transport.apiKeySecretArn).toEqual("dummy-arn-from-isecret");
   });
 });
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

[This PR](https://github.com/DataDog/datadog-cdk-constructs/issues/174) worked as a JS package, but produced a broken Python package. This was not caught in testing.

The issue stems from a bug with typescript intersection types compiled into python, [see here](https://github.com/DataDog/datadog-cdk-constructs/blob/2343119f325c942768291f1f05bbd292d5dc0c0a/v2/src/datadog.ts#L35) for the exact line.

This PR fixes this

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
