### PR TITLE
fix python cdk v1

### DIFF
--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -8,9 +8,9 @@
 
 import log from "loglevel";
 import { DefaultDatadogProps } from "./constants";
-import { IDatadogProps, DatadogStrictProps } from "./interfaces";
+import { DatadogProps, DatadogStrictProps } from "./interfaces";
 
-export function validateProps(props: IDatadogProps, apiKeyArnOverride = false) {
+export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {
   log.debug("Validating props...");
 
   checkForMultipleApiKeys(props, apiKeyArnOverride);
@@ -55,7 +55,7 @@ export function validateProps(props: IDatadogProps, apiKeyArnOverride = false) {
   }
 }
 
-export function checkForMultipleApiKeys(props: IDatadogProps, apiKeyArnOverride = false) {
+export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride = false) {
   let multipleApiKeysMessage;
   const apiKeyArnOrOverride = props.apiKeySecretArn !== undefined || apiKeyArnOverride;
   if (props.apiKey !== undefined && props.apiKmsKey !== undefined && apiKeyArnOrOverride) {
@@ -73,7 +73,7 @@ export function checkForMultipleApiKeys(props: IDatadogProps, apiKeyArnOverride 
   }
 }
 
-export function handleSettingPropDefaults(props: IDatadogProps): DatadogStrictProps {
+export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictProps {
   let addLayers = props.addLayers;
   let enableDatadogTracing = props.enableDatadogTracing;
   let enableMergeXrayTraces = props.enableMergeXrayTraces;

--- a/common/env.ts
+++ b/common/env.ts
@@ -7,7 +7,7 @@
  */
 
 import log from "loglevel";
-import { IDatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
+import { DatadogProps, DatadogStrictProps, ILambdaFunction } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
 export const ENABLE_XRAY_TRACE_MERGING_ENV_VAR = "DD_MERGE_XRAY_TRACES";
@@ -107,7 +107,7 @@ export function applyEnvVariables(lambdas: ILambdaFunction[], baseProps: Datadog
   });
 }
 
-export function setDDEnvVariables(lambdas: ILambdaFunction[], props: IDatadogProps) {
+export function setDDEnvVariables(lambdas: ILambdaFunction[], props: DatadogProps) {
   lambdas.forEach((lam) => {
     if (props.extensionLayerVersion) {
       if (props.env) {

--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -6,7 +6,7 @@
  * Copyright 2021 Datadog, Inc.
  */
 
-export interface IDatadogProps {
+export interface DatadogProps {
   readonly pythonLayerVersion?: number;
   readonly nodeLayerVersion?: number;
   readonly javaLayerVersion?: number;
@@ -16,7 +16,7 @@ export interface IDatadogProps {
   readonly flushMetricsToLogs?: boolean;
   readonly site?: string;
   readonly apiKey?: string;
-  apiKeySecretArn?: string;
+  readonly apiKeySecretArn?: string;
   readonly apiKmsKey?: string;
   readonly enableDatadogTracing?: boolean;
   readonly enableMergeXrayTraces?: boolean;

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -18,7 +18,7 @@ import {
   addForwarderToLogGroups,
   applyEnvVariables,
   applyLayers,
-  IDatadogProps,
+  DatadogProps,
   DatadogStrictProps,
   handleSettingPropDefaults,
   redirectHandlers,
@@ -32,9 +32,9 @@ const versionJson = require("../version.json");
 
 export class Datadog extends cdk.Construct {
   scope: cdk.Construct;
-  props: IDatadogProps;
+  props: DatadogProps;
   transport: Transport;
-  constructor(scope: cdk.Construct, id: string, props: IDatadogProps) {
+  constructor(scope: cdk.Construct, id: string, props: DatadogProps) {
     if (process.env.DD_CONSTRUCT_DEBUG_LOGS?.toLowerCase() == "true") {
       log.setLevel("debug");
     }
@@ -132,7 +132,7 @@ export function addCdkConstructVersionTag(lambdaFunctions: lambda.Function[]) {
   });
 }
 
-function setTags(lambdaFunctions: lambda.Function[], props: IDatadogProps) {
+function setTags(lambdaFunctions: lambda.Function[], props: DatadogProps) {
   log.debug(`Adding datadog tags`);
   lambdaFunctions.forEach((functionName) => {
     if (props.forwarderArn) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

fixes python cdk v1. My prev PR changed the DatadogProps interface to IDatadogProps, which caused JSII to not expand the IDatadogProps fields as parameters to `class Datadog`

See photos:
<img width="570" alt="image" src="https://github.com/DataDog/datadog-cdk-constructs/assets/51187184/6dcddac2-3c46-412a-bd0c-eaa238f98cfe">
(working, see how all props are expanded as parameters)

<img width="570" alt="image" src="https://github.com/DataDog/datadog-cdk-constructs/assets/51187184/7ea103ac-028e-42f5-ae5f-badc6f29fc46">

(broken)

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

Tested on v1 & v2 python & javascript

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
