### PR TITLE
[SLS-3290] Allow cdk v1 + v2 to use layers from another account

### DIFF
--- a/common/interfaces.ts
+++ b/common/interfaces.ts
@@ -38,6 +38,7 @@ export interface DatadogProps {
   readonly decodeAuthorizerContext?: boolean;
   readonly apmFlushDeadline?: string | number;
   readonly redirectHandler?: boolean;
+  readonly useLayersFromAccount?: string;
 }
 
 /*

--- a/v1/src/datadog.ts
+++ b/v1/src/datadog.ts
@@ -69,6 +69,7 @@ export class Datadog extends cdk.Construct {
           this.props.nodeLayerVersion,
           this.props.javaLayerVersion,
           this.props.extensionLayerVersion,
+          this.props.useLayersFromAccount,
         );
       }
 

--- a/v1/src/layer.ts
+++ b/v1/src/layer.ts
@@ -29,6 +29,7 @@ export function applyLayers(
   nodeLayerVersion?: number,
   javaLayerVersion?: number,
   extensionLayerVersion?: number,
+  useLayersFromAccount?: string,
 ) {
   // TODO: check region availability
   const errors: string[] = [];
@@ -43,6 +44,7 @@ export function applyLayers(
       return;
     }
 
+    const accountId = useLayersFromAccount;
     let lambdaLayerArn;
     let extensionLayerArn;
     if (lambdaRuntimeType === RuntimeType.PYTHON) {
@@ -52,7 +54,7 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, pythonLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, pythonLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using Python Lambda layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
@@ -64,7 +66,7 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using Node Lambda layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
@@ -76,13 +78,13 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using dd-trace-java layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
 
     if (extensionLayerVersion !== undefined) {
-      extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM);
+      extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM, accountId);
       log.debug(`Using extension layer: ${extensionLayerArn}`);
       addLayer(extensionLayerArn, true, scope, lam, runtime);
     }

--- a/v1/test/datadog.spec.ts
+++ b/v1/test/datadog.spec.ts
@@ -7,6 +7,7 @@ import { addCdkConstructVersionTag, checkForMultipleApiKeys, Datadog, DD_HANDLER
 const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
 const NODE_LAYER_VERSION = 1;
+const PYTHON_LAYER_VERSION = 2;
 
 describe("validateProps", () => {
   it("throws an error when the site is set to an invalid site URL", () => {
@@ -94,7 +95,7 @@ describe("validateProps", () => {
     });
     expect(() => {
       const datadogCDK = new Datadog(stack, "Datadog", {
-        forwarderArn: "forwarder-arn",
+        forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
         flushMetricsToLogs: false,
         site: "datadoghq.com",
       });
@@ -199,7 +200,7 @@ describe("addCdkConstructVersionTag", () => {
       enableDatadogTracing: false,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       apiKey: "1234",
     });
 
@@ -224,7 +225,7 @@ describe("addCdkConstructVersionTag", () => {
       enableDatadogTracing: false,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       apiKey: "1234",
     });
 
@@ -294,12 +295,13 @@ describe("setTags", () => {
 
     const datadogCdk = new Datadog(stack, "Datadog", {
       nodeLayerVersion: NODE_LAYER_VERSION,
+      pythonLayerVersion: PYTHON_LAYER_VERSION,
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       addLayers: true,
       enableDatadogTracing: false,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       apiKey: "1234",
       env: "test-env",
       service: "test-service",
@@ -435,12 +437,12 @@ describe("redirectHandler", () => {
     });
 
     const datadogCdk = new Datadog(stack, "Datadog", {
-      redirectHandler: false
+      redirectHandler: false,
     });
     datadogCdk.addLambdaFunctions([hello]);
 
     expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
-      Handler: "hello.handler"
+      Handler: "hello.handler",
     });
   });
 
@@ -457,16 +459,15 @@ describe("redirectHandler", () => {
       handler: "hello.handler",
     });
 
-    const datadogCdk = new Datadog(stack, "Datadog", {});
+    const datadogCdk = new Datadog(stack, "Datadog", { nodeLayerVersion: NODE_LAYER_VERSION });
     datadogCdk.addLambdaFunctions([hello]);
 
     expect(stack).toHaveResourceLike("AWS::Lambda::Function", {
       Environment: {
         Variables: {
-          [DD_HANDLER_ENV_VAR]: "hello.handler"
-        }
-      }
+          [DD_HANDLER_ENV_VAR]: "hello.handler",
+        },
+      },
     });
   });
 });
-

--- a/v1/test/env.spec.ts
+++ b/v1/test/env.spec.ts
@@ -36,7 +36,7 @@ describe("applyEnvVariables", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
     });
     datadogCDK.addLambdaFunctions([hello]);
     expect(stack).toHaveResource("AWS::Lambda::Function", {
@@ -69,7 +69,7 @@ describe("applyEnvVariables", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       logLevel: EXAMPLE_LOG_LEVEL,
     });
     datadogCDK.addLambdaFunctions([hello]);
@@ -106,7 +106,7 @@ describe("setDDEnvVariables", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       logLevel: EXAMPLE_LOG_LEVEL,
       enableColdStartTracing: false,
       minColdStartTraceDuration: 80,
@@ -286,7 +286,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       injectLogContext: false,
       sourceCodeIntegration: false,
     });
@@ -320,7 +320,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
@@ -354,7 +354,7 @@ describe("LOG_LEVEL_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       logLevel: "debug",
       sourceCodeIntegration: false,
     });

--- a/v1/test/forwarder.spec.ts
+++ b/v1/test/forwarder.spec.ts
@@ -20,9 +20,9 @@ describe("Forwarder", () => {
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
-    addForwarder(stack, [pythonLambda], "forwarder-arn");
+    addForwarder(stack, [pythonLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       FilterPattern: "",
     });
   });
@@ -45,7 +45,7 @@ describe("Forwarder", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda, pythonLambda], "forwarder-arn");
+    addForwarder(stack, [nodeLambda, pythonLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -72,8 +72,8 @@ describe("Forwarder", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda], "forwarder-arn");
-    addForwarder(stack, [pythonLambda], "forwarder-arn-2");
+    addForwarder(stack, [nodeLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
+    addForwarder(stack, [pythonLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn-2");
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -97,7 +97,7 @@ describe("Forwarder", () => {
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
-      addForwarder(stack, [pythonLambda], "forwarder-arn");
+      addForwarder(stack, [pythonLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
 
       return stack;
     };
@@ -137,8 +137,8 @@ describe("Forwarder", () => {
       return stack;
     };
 
-    const stackOne = createStack("forwarder-arn");
-    const stackTwo = createStack("forwarder-arn-2");
+    const stackOne = createStack("arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
+    const stackTwo = createStack("arn:aws:lambda:sa-east-1:123:function:forwarder-arn-2");
 
     const stackOneSubscriptions = findDatadogSubscriptionFilters(stackOne);
     const stackTwoSubscriptions = findDatadogSubscriptionFilters(stackTwo);
@@ -174,9 +174,9 @@ describe("Forwarder", () => {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-    addForwarderToLogGroups(stack, [restLogGroup], "forwarder-arn");
+    addForwarderToLogGroups(stack, [restLogGroup], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       FilterPattern: "",
     });
   });
@@ -188,9 +188,9 @@ describe("Forwarder", () => {
       },
     });
     const logGroup = LogGroup.fromLogGroupName(stack, "LogGroup", "logGroupName");
-    addForwarderToLogGroups(stack, [logGroup], "forwarder-arn");
+    addForwarderToLogGroups(stack, [logGroup], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       FilterPattern: "",
     });
   });
@@ -226,7 +226,11 @@ describe("Forwarder", () => {
       },
     });
 
-    addForwarderToLogGroups(stack, [nodeLogGroup, pythonLogGroup], "forwarder-arn");
+    addForwarderToLogGroups(
+      stack,
+      [nodeLogGroup, pythonLogGroup],
+      "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
+    );
     const stackSubcriptions = findDatadogSubscriptionFilters(stack);
 
     expect(stackSubcriptions).toHaveLength(2);
@@ -250,14 +254,14 @@ describe("Forwarder", () => {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-    addForwarder(stack, [pythonLambda], "forwarder-arn");
-    addForwarderToLogGroups(stack, [restLogGroup], "forwarder-arn-rest");
+    addForwarder(stack, [pythonLambda], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn");
+    addForwarderToLogGroups(stack, [restLogGroup], "arn:aws:lambda:sa-east-1:123:function:forwarder-arn-rest");
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       FilterPattern: "",
     });
     expect(stack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn-rest",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn-rest",
       FilterPattern: "",
     });
   });

--- a/v1/test/index.spec.ts
+++ b/v1/test/index.spec.ts
@@ -40,7 +40,7 @@ describe("addLambdaFunctions", () => {
       nodeLayerVersion: 20,
       pythonLayerVersion: 28,
       addLayers: true,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       enableDatadogTracing: true,
       enableDatadogLogs: true,
       flushMetricsToLogs: true,
@@ -72,7 +72,7 @@ describe("addLambdaFunctions", () => {
       nodeLayerVersion: 20,
       pythonLayerVersion: 28,
       addLayers: true,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       enableDatadogTracing: true,
       enableDatadogLogs: true,
       flushMetricsToLogs: true,
@@ -102,7 +102,7 @@ describe("addLambdaFunctions", () => {
       nodeLayerVersion: 20,
       pythonLayerVersion: 28,
       addLayers: true,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       enableDatadogTracing: true,
       enableDatadogLogs: true,
       flushMetricsToLogs: true,
@@ -111,7 +111,7 @@ describe("addLambdaFunctions", () => {
     NestedStackDatadogCdk.addLambdaFunctions([NestedStackLambda]);
 
     expect(NestedStack).toHaveResource("AWS::Logs::SubscriptionFilter", {
-      DestinationArn: "forwarder-arn",
+      DestinationArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       FilterPattern: "",
     });
   });
@@ -168,7 +168,7 @@ describe("applyLayers", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
@@ -230,7 +230,7 @@ describe("applyLayers", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
@@ -278,7 +278,7 @@ describe("applyLayers", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       nodeLayerVersion: 39,
       pythonLayerVersion: 24,
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello, hello1, hello2]);

--- a/v1/test/transport.spec.ts
+++ b/v1/test/transport.spec.ts
@@ -31,7 +31,7 @@ describe("SITE_URL_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       site: "datadoghq.eu",
       flushMetricsToLogs: false,
       apiKey: "1234",
@@ -68,7 +68,7 @@ describe("SITE_URL_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       flushMetricsToLogs: false,
       apiKey: "1234",
       sourceCodeIntegration: false,
@@ -175,7 +175,7 @@ describe("SITE_URL_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       flushMetricsToLogs: true,
       site: "datadoghq.eu",
       sourceCodeIntegration: false,
@@ -211,7 +211,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       apiKey: "1234",
       flushMetricsToLogs: false,
       site: "datadoghq.com",
@@ -248,7 +248,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       sourceCodeIntegration: false,
     });
     datadogCDK.addLambdaFunctions([hello]);
@@ -318,7 +318,7 @@ describe("API_KEY_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKey: "1234",
@@ -455,7 +455,7 @@ describe("apiKMSKeyEnvVar", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      forwarderArn: "forwarder-arn",
+      forwarderArn: "arn:aws:lambda:sa-east-1:123:function:forwarder-arn",
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKmsKey: "5678",

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -81,6 +81,7 @@ export class Datadog extends Construct {
           this.props.nodeLayerVersion,
           this.props.javaLayerVersion,
           this.props.extensionLayerVersion,
+          this.props.useLayersFromAccount,
         );
       }
 

--- a/v2/src/interfacesV2.ts
+++ b/v2/src/interfacesV2.ts
@@ -41,4 +41,5 @@ export interface DatadogPropsV2 {
   readonly decodeAuthorizerContext?: boolean;
   readonly apmFlushDeadline?: string | number;
   readonly redirectHandler?: boolean;
+  readonly useLayersFromAccount?: string;
 }

--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -29,6 +29,7 @@ export function applyLayers(
   nodeLayerVersion?: number,
   javaLayerVersion?: number,
   extensionLayerVersion?: number,
+  useLayersFromAccount?: string,
 ) {
   // TODO: check region availability
   const errors: string[] = [];
@@ -45,6 +46,7 @@ export function applyLayers(
       return;
     }
 
+    const accountId = useLayersFromAccount;
     let lambdaLayerArn;
     let extensionLayerArn;
     if (lambdaRuntimeType === RuntimeType.PYTHON) {
@@ -54,7 +56,7 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, pythonLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, pythonLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using Python Lambda layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
@@ -66,7 +68,7 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, nodeLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using Node Lambda layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
@@ -78,13 +80,13 @@ export function applyLayers(
         errors.push(errorMessage);
         return;
       }
-      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode);
+      lambdaLayerArn = getLambdaLayerArn(region, javaLayerVersion, runtime, isARM, isNode, accountId);
       log.debug(`Using dd-trace-java layer: ${lambdaLayerArn}`);
       addLayer(lambdaLayerArn, false, scope, lam, runtime);
     }
 
     if (extensionLayerVersion !== undefined) {
-      extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM);
+      extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM, accountId);
       log.debug(`Using extension layer: ${extensionLayerArn}`);
       addLayer(extensionLayerArn, true, scope, lam, runtime);
     }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds the optional parameter `useLayersFromAccount` || `use_layers_from_account` to allow our CDK to use DD Lambda layers of the same name published into the executing account. For this special case, we make sure the feature is region agnostic.

### Motivation

<!--- What inspired you to submit this pull request? --->
Work that is in line with https://github.com/DataDog/serverless-plugin-datadog/pull/386 

### Testing Guidelines

<!--- How did you test this pull request? --->
Tested manually v1 and v2 with node + python examples. Updated a handful of the unit tests for v1 since they were all failing with `ARNs must start with "arn:" and have at least 6 components` errors.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
