### PR TITLE
Resolve v2 unit test console errors

### DIFF
--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -6,7 +6,8 @@ import { addCdkConstructVersionTag, checkForMultipleApiKeys, Datadog, DD_HANDLER
 const { ISecret } = require("aws-cdk-lib/aws-secretsmanager");
 const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
-const NODE_LAYER_VERSION = 1;
+const NODE_LAYER_VERSION = 91;
+const PYTHON_LAYER_VERSION = 73;
 
 describe("validateProps", () => {
   it("throws an error when the site is set to an invalid site URL", () => {
@@ -331,6 +332,7 @@ describe("setTags", () => {
 
     const datadogCdk = new Datadog(stack, "Datadog", {
       nodeLayerVersion: NODE_LAYER_VERSION,
+      pythonLayerVersion: PYTHON_LAYER_VERSION,
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       addLayers: true,
       enableDatadogTracing: false,
@@ -424,6 +426,7 @@ describe("setTags", () => {
 
     const datadogCdk = new Datadog(stack, "Datadog", {
       nodeLayerVersion: NODE_LAYER_VERSION,
+      pythonLayerVersion: PYTHON_LAYER_VERSION,
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       addLayers: true,
       enableDatadogTracing: false,
@@ -578,6 +581,7 @@ describe("redirectHandler", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       redirectHandler: false,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
 
@@ -598,7 +602,7 @@ describe("redirectHandler", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    const datadogCDK = new Datadog(stack, "Datadog", {});
+    const datadogCDK = new Datadog(stack, "Datadog", { nodeLayerVersion: NODE_LAYER_VERSION });
     datadogCDK.addLambdaFunctions([hello]);
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -16,6 +16,8 @@ import {
   API_KEY_ENV_VAR,
 } from "../src/index";
 
+const NODE_LAYER_VERSION = 91;
+
 jest.mock("child_process", () => {
   return {
     execSync: () => "1234",
@@ -37,6 +39,7 @@ describe("applyEnvVariables", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -70,6 +73,7 @@ describe("applyEnvVariables", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
       logLevel: EXAMPLE_LOG_LEVEL,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -113,6 +117,7 @@ describe("setDDEnvVariables", () => {
       encodeAuthorizerContext: false,
       decodeAuthorizerContext: false,
       apmFlushDeadline: "20",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -154,6 +159,7 @@ describe("ENABLE_DD_TRACING_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       enableDatadogTracing: false,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -182,7 +188,7 @@ describe("ENABLE_DD_TRACING_ENV_VAR", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    const datadogCDK = new Datadog(stack, "Datadog", {});
+    const datadogCDK = new Datadog(stack, "Datadog", { nodeLayerVersion: NODE_LAYER_VERSION });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Environment: {
@@ -214,6 +220,7 @@ describe("ENABLE_XRAY_TRACE_MERGING_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       enableMergeXrayTraces: true,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -243,7 +250,7 @@ describe("ENABLE_XRAY_TRACE_MERGING_ENV_VAR", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    const datadogCDK = new Datadog(stack, "Datadog", {});
+    const datadogCDK = new Datadog(stack, "Datadog", { nodeLayerVersion: NODE_LAYER_VERSION });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Environment: {
@@ -277,6 +284,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
       injectLogContext: false,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
 
@@ -308,6 +316,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -341,6 +350,7 @@ describe("LOG_LEVEL_ENV_VAR", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
       logLevel: "debug",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
 
@@ -375,6 +385,7 @@ describe("ENABLE_DD_LOGS_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       enableDatadogLogs: false,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -403,7 +414,7 @@ describe("ENABLE_DD_LOGS_ENV_VAR", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    const datadogCDK = new Datadog(stack, "Datadog", {});
+    const datadogCDK = new Datadog(stack, "Datadog", { nodeLayerVersion: NODE_LAYER_VERSION });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Environment: {
@@ -435,6 +446,7 @@ describe("DD_TAGS_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       captureLambdaPayload: true,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -465,6 +477,7 @@ describe("DD_TAGS_ENV_VAR", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
       captureLambdaPayload: true,
       tags: "key:value",
       // the below fields are needed or DD_TAGS won't get set
@@ -505,6 +518,7 @@ describe("DD_TAGS_ENV_VAR", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       captureLambdaPayload: true,
       sourceCodeIntegration: false,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -537,6 +551,7 @@ describe("CAPTURE_LAMBDA_PAYLOAD_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       captureLambdaPayload: true,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -567,6 +582,7 @@ describe("CAPTURE_LAMBDA_PAYLOAD_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       captureLambdaPayload: undefined,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {

--- a/v2/test/layer.spec.ts
+++ b/v2/test/layer.spec.ts
@@ -3,6 +3,7 @@ import { App, Stack } from "aws-cdk-lib";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Architecture } from "aws-cdk-lib/aws-lambda";
+import log from "loglevel";
 import {
   Datadog,
   applyLayers,
@@ -12,8 +13,8 @@ import {
   generateLambdaLayerId,
   generateExtensionLayerId,
 } from "../src/index";
-const NODE_LAYER_VERSION = 1;
-const PYTHON_LAYER_VERSION = 2;
+const NODE_LAYER_VERSION = 91;
+const PYTHON_LAYER_VERSION = 73;
 const EXTENSION_LAYER_VERSION = 5;
 
 describe("applyLayers", () => {
@@ -236,6 +237,7 @@ describe("applyLayers", () => {
   });
 
   it("returns errors if layer versions are not provided for corresponding Lambda runtimes", () => {
+    const logSpy = jest.spyOn(log, "error").mockImplementation(() => ({}));
     const app = new App();
     const stack = new Stack(app, "stack", {
       env: {
@@ -260,6 +262,8 @@ describe("applyLayers", () => {
       getMissingLayerVersionErrorMsg("NodeHandler", "Node.js", "node"),
       getMissingLayerVersionErrorMsg("PythonHandler", "Python", "python"),
     ]);
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    logSpy.mockRestore();
   });
 });
 

--- a/v2/test/transport.spec.ts
+++ b/v2/test/transport.spec.ts
@@ -15,6 +15,8 @@ import {
   DD_HANDLER_ENV_VAR,
 } from "../src/index";
 const EXTENSION_LAYER_VERSION = 5;
+const NODE_LAYER_VERSION = 91;
+const PYTHON_LAYER_VERSION = 73;
 
 describe("SITE_URL_ENV_VAR", () => {
   it("applies site URL parameter correctly when flushMetricsToLogs is false", () => {
@@ -34,6 +36,7 @@ describe("SITE_URL_ENV_VAR", () => {
       site: "datadoghq.eu",
       flushMetricsToLogs: false,
       apiKey: "1234",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -68,6 +71,7 @@ describe("SITE_URL_ENV_VAR", () => {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
       flushMetricsToLogs: false,
       apiKey: "1234",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -101,6 +105,7 @@ describe("SITE_URL_ENV_VAR", () => {
     const datadogCDK = new Datadog(stack, "Datadog", {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       apiKey: "1234",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -135,6 +140,7 @@ describe("SITE_URL_ENV_VAR", () => {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       site: "datadoghq.eu",
       apiKey: "1234",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -169,6 +175,7 @@ describe("SITE_URL_ENV_VAR", () => {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
       flushMetricsToLogs: true,
       site: "datadoghq.eu",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -204,6 +211,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       apiKey: "1234",
       flushMetricsToLogs: false,
       site: "datadoghq.com",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -236,6 +244,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       forwarderArn: "arn:test:forwarder:sa-east-1:12345678:1",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -268,6 +277,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
       apiKey: "1234",
       flushMetricsToLogs: true,
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -305,6 +315,7 @@ describe("API_KEY_ENV_VAR", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKey: "1234",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -342,6 +353,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       flushMetricsToLogs: true,
       site: "datadoghq.com",
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -377,6 +389,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
         flushMetricsToLogs: false,
         site: "datadoghq.com",
         apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
+        nodeLayerVersion: NODE_LAYER_VERSION,
       });
       datadogCDK.addLambdaFunctions([hello]);
     }).toThrowError(
@@ -400,6 +413,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKeySecretArn: "some-resource:from:aws:secrets-manager:arn",
+      pythonLayerVersion: PYTHON_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -436,6 +450,7 @@ describe("apiKMSKeyEnvVar", () => {
       flushMetricsToLogs: false,
       site: "datadoghq.com",
       apiKmsKey: "5678",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Resolves console errors displayed when running v2 unit tests.

### Motivation

https://datadoghq.atlassian.net/browse/SLS-3061

### Testing Guidelines

Ran `yarn test` and confirmed that no more console errors were displayed in the unit test output.

![Image 2023-06-14 at 1 22 05 PM](https://github.com/DataDog/datadog-cdk-constructs/assets/35278470/989b2488-7de1-4cc2-946d-560f12b4fc3f)

### Additional Notes

Console errors were the result of a missing `nodeLayerVersion` or `pythonLayerVersion` parameter when initializing the Datadog CDK. The majority of the errors were resolved by adding the missing parameter.

One unit test asserted that the error messages are present when the parameters are missing so for this case the errors were resolved by mocking the log library to not display the error message in the console.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
