### PR TITLE
Allow bypassing site check

### DIFF
--- a/common/datadogSharedLogic.ts
+++ b/common/datadogSharedLogic.ts
@@ -26,7 +26,7 @@ export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {
     props.site !== undefined &&
     !siteList.includes(props.site.toLowerCase()) &&
     !(props.site.startsWith("${Token[") && props.site.endsWith("]}")) &&
-    process.env.DD_CDK_BYPASS_SITE_VALIDATION !== "true"
+    !process.env.DD_CDK_BYPASS_SITE_VALIDATION
   ) {
     throw new Error(
       "Warning: Invalid site URL. Must be either datadoghq.com, datadoghq.eu, us3.datadoghq.com, us5.datadoghq.com, ap1.datadoghq.com, or ddog-gov.com.",

--- a/v1/test/datadog.spec.ts
+++ b/v1/test/datadog.spec.ts
@@ -79,7 +79,7 @@ describe("validateProps", () => {
     }
     expect(threwError).toBe(false);
     expect(thrownError?.message).toEqual(undefined);
-    process.env.DD_CDK_BYPASS_SITE_VALIDATION = "undefined";
+    process.env.DD_CDK_BYPASS_SITE_VALIDATION = undefined;
   });
 
   it("doesn't throw an error when the site is set as a cdk token", () => {

--- a/v1/test/datadog.spec.ts
+++ b/v1/test/datadog.spec.ts
@@ -46,6 +46,42 @@ describe("validateProps", () => {
     );
   });
 
+  it("doesn't throw an error when the site is invalid and DD_CDK_BYPASS_SITE_VALIDATION is true", () => {
+    process.env.DD_CDK_BYPASS_SITE_VALIDATION = "true";
+    const app = new cdk.App();
+    const stack = new cdk.Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    let threwError = false;
+    let thrownError: Error | undefined;
+    try {
+      const datadogCdk = new Datadog(stack, "Datadog", {
+        nodeLayerVersion: NODE_LAYER_VERSION,
+        extensionLayerVersion: EXTENSION_LAYER_VERSION,
+        apiKey: "1234",
+        enableDatadogTracing: false,
+        flushMetricsToLogs: false,
+        site: "dataDOGEhq.com",
+      });
+      datadogCdk.addLambdaFunctions([hello]);
+    } catch (e) {
+      threwError = true;
+      if (e instanceof Error) {
+        thrownError = e;
+      }
+    }
+    expect(threwError).toBe(false);
+    expect(thrownError?.message).toEqual(undefined);
+    process.env.DD_CDK_BYPASS_SITE_VALIDATION = "undefined";
+  });
+
   it("doesn't throw an error when the site is set as a cdk token", () => {
     const app = new cdk.App();
     const stack = new cdk.Stack(app, "stack", {


### PR DESCRIPTION
### What does this PR do?

Allow bypassing the site-check when the environment variable `DD_CDK_BYPASS_SITE_VALIDATION` is set to "true"

### Motivation

Datadog developers need a way to bypass the site-check to manually test the CDK tool on staging or any other custom site that is not in `siteList`.

### Testing Guidelines

I wrote new tests for v1 and v2 to check that the site check passes when using an invalid site and `DD_CDK_BYPASS_SITE_VALIDATION` is set.

### Additional Notes

This is not intended to be used by users and only for developing and testing purposes.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
