### PR TITLE
Fix error when instrumenting Lambda container images 

### DIFF
--- a/v2/package.json
+++ b/v2/package.json
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.3",
+  "version": "0.0.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/package.json
+++ b/v2/package.json
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "version": "1.7.3",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -42,8 +42,6 @@ export function applyLayers(
       lam.architecture.dockerPlatform === Architecture.ARM_64.dockerPlatform;
     const isNode = lambdaRuntimeType === RuntimeType.NODE;
 
-    // console.log({ lam });
-
     if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
       log.debug(`Unsupported runtime: ${runtime}`);
       return;

--- a/v2/src/layer.ts
+++ b/v2/src/layer.ts
@@ -41,7 +41,10 @@ export function applyLayers(
       lam.architecture?.dockerPlatform !== undefined &&
       lam.architecture.dockerPlatform === Architecture.ARM_64.dockerPlatform;
     const isNode = lambdaRuntimeType === RuntimeType.NODE;
-    if (lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
+
+    // console.log({ lam });
+
+    if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
       log.debug(`Unsupported runtime: ${runtime}`);
       return;
     }

--- a/v2/test/assets/Dockerfile
+++ b/v2/test/assets/Dockerfile
@@ -1,0 +1,3 @@
+# Only used for tests
+
+FROM public.ecr.aws/lambda/nodejs:16-x86_64

--- a/v2/test/layer.spec.ts
+++ b/v2/test/layer.spec.ts
@@ -236,6 +236,60 @@ describe("applyLayers", () => {
     expect(errors.length).toEqual(0);
   });
 
+  it("doesn't add layer to container image Lambda without extension or layer versions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.DockerImageFunction(stack, "HelloHandler", {
+      functionName: "container-lambda",
+      code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
+    });
+    const datadogCdk = new Datadog(stack, "Datadog", {
+      apiKmsKey: "1234",
+      addLayers: true,
+      enableDatadogTracing: false,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    datadogCdk.addLambdaFunctions([hello]);
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Layers: Match.absent(),
+      Runtime: Match.absent(),
+      Handler: Match.absent(),
+    });
+  });
+
+  it("doesn't add layer to container image Lambda with extension and layer versions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.DockerImageFunction(stack, "HelloHandler", {
+      functionName: "container-lambda",
+      code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
+    });
+    const datadogCdk = new Datadog(stack, "Datadog", {
+      pythonLayerVersion: PYTHON_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKmsKey: "1234",
+      addLayers: true,
+      enableDatadogTracing: false,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    datadogCdk.addLambdaFunctions([hello]);
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Layers: Match.absent(),
+      Runtime: Match.absent(),
+      Handler: Match.absent(),
+    });
+  });
+
   it("returns errors if layer versions are not provided for corresponding Lambda runtimes", () => {
     const logSpy = jest.spyOn(log, "error").mockImplementation(() => ({}));
     const app = new App();

--- a/v2/test/layer.spec.ts
+++ b/v2/test/layer.spec.ts
@@ -273,6 +273,7 @@ describe("applyLayers", () => {
       functionName: "container-lambda",
       code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
     });
+
     const datadogCdk = new Datadog(stack, "Datadog", {
       pythonLayerVersion: PYTHON_LAYER_VERSION,
       extensionLayerVersion: EXTENSION_LAYER_VERSION,
@@ -283,6 +284,7 @@ describe("applyLayers", () => {
       site: "datadoghq.com",
     });
     datadogCdk.addLambdaFunctions([hello]);
+
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: Match.absent(),
       Runtime: Match.absent(),

--- a/v2/test/redirect.spec.ts
+++ b/v2/test/redirect.spec.ts
@@ -1,5 +1,5 @@
 import { App, Stack } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Template, Match } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import {
   redirectHandlers,
@@ -122,5 +122,23 @@ describe("redirectHandlers", () => {
       },
       0,
     );
+  });
+
+  it("doesn't set handler or runtime for container image functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.DockerImageFunction(stack, "HelloHandler", {
+      code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
+    });
+    redirectHandlers([hello], true);
+
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Handler: Match.absent(),
+      Runtime: Match.absent(),
+    });
   });
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

- Fixes the error brought up in https://github.com/DataDog/datadog-cdk-constructs/issues/185 by preventing the extension layer from being added to a Lambda container image
- Adds tests for the container image case

### Motivation
https://github.com/DataDog/datadog-cdk-constructs/issues/185

### Testing Guidelines
Deployed with example CDK Lambda container image project with the error no longer happening

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
