### PR TITLE
adds support for singleton functions

### DIFF
--- a/v2/integration_tests/snapshots/correct-lambda-singleton-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-singleton-function-stack-snapshot.json
@@ -1,0 +1,504 @@
+{
+ "Resources": {
+  "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/SingletonLambdab55587fe69854c28ab514d0edb1ba8a1/ServiceRole/Resource"
+   }
+  },
+  "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "test"
+    },
+    "Environment": {
+     "Variables": {
+      "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
+      "DD_TRACE_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_LOGS_INJECTION": "false",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_FLUSH_TO_LOG": "false",
+      "DD_SITE": "datadoghq.com",
+      "DD_API_KEY": "1234"
+     }
+    },
+    "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+    "Layers": [
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+    ],
+    "Role": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs14.x",
+    "Tags": [
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     }
+    ]
+   },
+   "DependsOn": [
+    "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/SingletonLambdab55587fe69854c28ab514d0edb1ba8a1/Resource"
+   }
+  },
+  "restLogGroupXXXXXXXX": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 731
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/restLogGroup/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "rest-test"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Resource"
+   }
+  },
+  "resttestCloudWatchRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/CloudWatchRole/Resource"
+   }
+  },
+  "resttestAccountXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "resttestCloudWatchRoleXXXXXXXX",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "resttestXXXXXXXX"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Account"
+   }
+  },
+  "resttestDeploymentXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "Automatically created by the RestApi construct",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "DependsOn": [
+    "resttestproxyANYXXXXXXXX",
+    "resttestproxyXXXXXXXX",
+    "resttestANYXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Deployment/Resource"
+   }
+  },
+  "resttestDeploymentStageprodXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "AccessLogSetting": {
+     "DestinationArn": {
+      "Fn::GetAtt": [
+       "restLogGroupXXXXXXXX",
+       "Arn"
+      ]
+     },
+     "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+    },
+    "DeploymentId": {
+     "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "resttestAccountXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/DeploymentStage.prod/Resource"
+   }
+  },
+  "resttestproxyXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/Resource"
+   }
+  },
+  "resttestproxyANYApiPermissionlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYApiPermissionTestlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "resttestANYApiPermissionlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/ApiPermission.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYApiPermissionTestlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "vX:XXXXXX:XXXXXX"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "resttestEndpointXXXXXXXX": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "resttestXXXXXXXX"
+      },
+      ".execute-api.sa-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "resttestDeploymentStageprodXXXXXXXX"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/v2/integration_tests/snapshots/test-lambda-singleton-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-singleton-function-stack-snapshot.json
@@ -1,0 +1,504 @@
+{
+ "Resources": {
+  "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/SingletonLambdab55587fe69854c28ab514d0edb1ba8a1/ServiceRole/Resource"
+   }
+  },
+  "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "test"
+    },
+    "Environment": {
+     "Variables": {
+      "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
+      "DD_TRACE_ENABLED": "true",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_LOGS_INJECTION": "false",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_FLUSH_TO_LOG": "false",
+      "DD_SITE": "datadoghq.com",
+      "DD_API_KEY": "1234"
+     }
+    },
+    "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+    "Layers": [
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+    ],
+    "Role": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs14.x",
+    "Tags": [
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     }
+    ]
+   },
+   "DependsOn": [
+    "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1ServiceRole5C6B0587"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/SingletonLambdab55587fe69854c28ab514d0edb1ba8a1/Resource"
+   }
+  },
+  "restLogGroupXXXXXXXX": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 731
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/restLogGroup/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "rest-test"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Resource"
+   }
+  },
+  "resttestCloudWatchRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/CloudWatchRole/Resource"
+   }
+  },
+  "resttestAccountXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "resttestCloudWatchRoleXXXXXXXX",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "resttestXXXXXXXX"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Account"
+   }
+  },
+  "resttestDeploymentXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "Automatically created by the RestApi construct",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "DependsOn": [
+    "resttestproxyANYXXXXXXXX",
+    "resttestproxyXXXXXXXX",
+    "resttestANYXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Deployment/Resource"
+   }
+  },
+  "resttestDeploymentStageprodXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "AccessLogSetting": {
+     "DestinationArn": {
+      "Fn::GetAtt": [
+       "restLogGroupXXXXXXXX",
+       "Arn"
+      ]
+     },
+     "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+    },
+    "DeploymentId": {
+     "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "resttestAccountXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/DeploymentStage.prod/Resource"
+   }
+  },
+  "resttestproxyXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/Resource"
+   }
+  },
+  "resttestproxyANYApiPermissionlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYApiPermissionTestlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestproxyANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "resttestANYApiPermissionlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/ApiPermission.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYApiPermissionTestlambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/ApiPermission.Test.lambdasingletonfunctionstackresttestXXXXXXXXANYXXXXXXXX"
+   }
+  },
+  "resttestANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "SingletonLambdab55587fe69854c28ab514d0edb1ba8a1E1AFAB02",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/rest-test/Default/ANY/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "vX:XXXXXX:XXXXXX"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-singleton-function-stack/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "resttestEndpointXXXXXXXX": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "resttestXXXXXXXX"
+      },
+      ".execute-api.sa-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "resttestDeploymentStageprodXXXXXXXX"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/v2/integration_tests/stacks/lambda-singleton-function-stack.ts
+++ b/v2/integration_tests/stacks/lambda-singleton-function-stack.ts
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import { Stack, StackProps, App } from "aws-cdk-lib"
+import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { Datadog } from "../../src/index";
+
+export class ExampleStack extends Stack {
+  constructor(scope: App, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const singletonLambdaFunction = new lambda.SingletonFunction(this, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_14_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "lambdaFunction.handler",
+      "uuid": "b55587fe-6985-4c28-ab51-4d0edb1ba8a1"
+    });
+
+    const restLogGroup = new LogGroup(this, "restLogGroup");
+    new LambdaRestApi(this, "rest-test", {
+      handler: singletonLambdaFunction,
+      deployOptions: {
+        accessLogDestination: new LogGroupLogDestination(restLogGroup),
+      },
+    });
+  
+    const datadogCDK = new Datadog(this, "Datadog", {
+      nodeLayerVersion: 62,
+      extensionLayerVersion: 10,
+      enableDatadogTracing: true,
+      flushMetricsToLogs: true,
+      sourceCodeIntegration: false,
+      apiKey: "1234",
+      site: "datadoghq.com",
+    });
+    datadogCDK.addLambdaFunctions([singletonLambdaFunction]);
+    datadogCDK.addForwarderToNonLambdaLogGroups([restLogGroup]);
+  }
+}
+
+const app = new App();
+const env = { account: "601427279990", region: "sa-east-1" };
+const stack = new ExampleStack(app, "lambda-singleton-function-stack", { env: env });
+console.log("Stack name: " + stack.stackName);
+app.synth();

--- a/v2/scripts/run_integration_tests.sh
+++ b/v2/scripts/run_integration_tests.sh
@@ -11,7 +11,7 @@ set -e
 # To add new tests create a new ts file in the 'integration_tests/stacks' directory, append its file name to the STACK_CONFIGS array.
 # Note: Each ts file will have its respective snapshot built in the snapshots directory, e.g. lambda-function-stack.ts
 #       will generate both snapshots/test-lambda-function-stack-snapshot.json and snapshots/correct-lambda-function-stack-snapshot.json
-STACK_CONFIGS=("lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack" "lambda-java-function-stack")
+STACK_CONFIGS=("lambda-singleton-function-stack" "lambda-function-arm-stack" "lambda-function-stack" "lambda-nodejs-function-stack" "lambda-python-function-stack" "lambda-java-function-stack")
 
 SCRIPT_PATH=${BASH_SOURCE[0]}
 SCRIPTS_DIR=$(dirname $SCRIPT_PATH)

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -203,9 +203,9 @@ function grantReadLambdasFromSecretArn(construct: Construct, arn: string, lambda
 function extractSingletonFunctions(lambdaFunctions: LambdaFunction[]) {
   // extract lambdaFunction property from Singleton Function
   // using any here since lambdaFunction is a private property
-  const extractedLambdaFunctions: lambda.Function[] = lambdaFunctions.map((fn: any) => {
+  const extractedLambdaFunctions: lambda.Function[] = lambdaFunctions.map((fn) => {
     if (fn.hasOwnProperty("lambdaFunction")) {
-      return fn.lambdaFunction;
+      return (fn as any).lambdaFunction;
     }
     return fn;
   });

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -202,10 +202,10 @@ function grantReadLambdasFromSecretArn(construct: Construct, arn: string, lambda
 
 function extractSingletonFunctions(lambdaFunctions: LambdaFunction[]) {
   // extract lambdaFunction property from Singleton Function
-  // using any here since lambdaFunction is a private property
+  // using bracket notation here since lambdaFunction is a private property
   const extractedLambdaFunctions: lambda.Function[] = lambdaFunctions.map((fn) => {
     if (fn.hasOwnProperty("lambdaFunction")) {
-      return (fn as any).lambdaFunction;
+      return (fn as lambda.SingletonFunction)["lambdaFunction"]; // eslint-disable-line dot-notation
     }
     return fn;
   });

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -204,13 +204,15 @@ function extractSingletonFunctions(lambdaFunctions: LambdaFunction[]) {
   // extract lambdaFunction property from Singleton Function
   // using bracket notation here since lambdaFunction is a private property
   const extractedLambdaFunctions: lambda.Function[] = lambdaFunctions.map((fn) => {
-    if (fn.hasOwnProperty("lambdaFunction")) {
-      return (fn as lambda.SingletonFunction)["lambdaFunction"]; // eslint-disable-line dot-notation
-    }
-    return fn;
+    // eslint-disable-next-line dot-notation
+    return isSingletonFunction(fn) ? fn["lambdaFunction"] : fn;
   });
 
   return extractedLambdaFunctions;
+}
+
+function isSingletonFunction(fn: LambdaFunction): fn is lambda.SingletonFunction {
+  return fn.hasOwnProperty("lambdaFunction");
 }
 
 export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -6,10 +6,8 @@
  * Copyright 2021 Datadog, Inc.
  */
 
-import * as lambdaPython from "@aws-cdk/aws-lambda-python-alpha";
 import { Tags } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import { ISecret, Secret } from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
@@ -28,6 +26,7 @@ import {
   DatadogProps,
   Transport,
 } from "./index";
+import { LambdaFunction } from "./interfaces";
 
 const versionJson = require("../version.json");
 
@@ -57,33 +56,32 @@ export class Datadog extends Construct {
     );
   }
 
-  public addLambdaFunctions(
-    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
-    construct?: Construct,
-  ) {
+  public addLambdaFunctions(lambdaFunctions: LambdaFunction[], construct?: Construct) {
     // baseProps contains all properties set by the user, with default values for properties
     // defined in DefaultDatadogProps (if not set by user)
     const baseProps: DatadogStrictProps = handleSettingPropDefaults(this.props);
 
-    if (this.props !== undefined && lambdaFunctions.length > 0) {
+    const extractedLambdaFunctions = extractSingletonFunctions(lambdaFunctions);
+
+    if (this.props !== undefined && extractedLambdaFunctions.length > 0) {
       if (this.props.apiKeySecret !== undefined) {
-        grantReadLambdas(this.props.apiKeySecret, lambdaFunctions);
+        grantReadLambdas(this.props.apiKeySecret, extractedLambdaFunctions);
       } else if (
         this.props.apiKeySecretArn !== undefined &&
         construct !== undefined &&
         baseProps.grantSecretReadAccess
       ) {
         log.debug("Granting read access to the provided Secret ARN for all your lambda functions.");
-        grantReadLambdasFromSecretArn(construct, this.props.apiKeySecretArn, lambdaFunctions);
+        grantReadLambdasFromSecretArn(construct, this.props.apiKeySecretArn, extractedLambdaFunctions);
       }
 
-      const region = `${lambdaFunctions[0].env.region}`;
+      const region = `${extractedLambdaFunctions[0].env.region}`;
       log.debug(`Using region: ${region}`);
       if (baseProps.addLayers) {
         applyLayers(
           this.scope,
           region,
-          lambdaFunctions,
+          extractedLambdaFunctions,
           this.props.pythonLayerVersion,
           this.props.nodeLayerVersion,
           this.props.javaLayerVersion,
@@ -93,7 +91,7 @@ export class Datadog extends Construct {
       }
 
       if (baseProps.redirectHandler) {
-        redirectHandlers(lambdaFunctions, baseProps.addLayers);
+        redirectHandlers(extractedLambdaFunctions, baseProps.addLayers);
       }
 
       if (this.props.forwarderArn !== undefined) {
@@ -103,7 +101,7 @@ export class Datadog extends Construct {
           log.debug(`Adding log subscriptions using provided Forwarder ARN: ${this.props.forwarderArn}`);
           addForwarder(
             this.scope,
-            lambdaFunctions,
+            extractedLambdaFunctions,
             this.props.forwarderArn,
             this.props.createForwarderPermissions === true,
           );
@@ -112,23 +110,23 @@ export class Datadog extends Construct {
         log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
       }
 
-      addCdkConstructVersionTag(lambdaFunctions);
+      addCdkConstructVersionTag(extractedLambdaFunctions);
 
-      applyEnvVariables(lambdaFunctions, baseProps);
-      setDDEnvVariables(lambdaFunctions, this.props);
-      setTags(lambdaFunctions, this.props);
+      applyEnvVariables(extractedLambdaFunctions, baseProps);
+      setDDEnvVariables(extractedLambdaFunctions, this.props);
+      setTags(extractedLambdaFunctions, this.props);
 
-      this.transport.applyEnvVars(lambdaFunctions);
+      this.transport.applyEnvVars(extractedLambdaFunctions);
 
       if (baseProps.sourceCodeIntegration) {
-        this.addGitCommitMetadata(lambdaFunctions);
+        this.addGitCommitMetadata(extractedLambdaFunctions);
       }
     }
   }
 
   // unused parameters gitCommitSha and gitRepoUrl are kept for backwards compatibility
   public addGitCommitMetadata(
-    lambdaFunctions: (lambda.Function | lambdaNodejs.NodejsFunction | lambdaPython.PythonFunction)[],
+    lambdaFunctions: LambdaFunction[],
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     gitCommitSha?: string,
@@ -136,7 +134,8 @@ export class Datadog extends Construct {
     // @ts-ignore
     gitRepoUrl?: string,
   ) {
-    setGitEnvironmentVariables(lambdaFunctions);
+    const extractedLambdaFunctions = extractSingletonFunctions(lambdaFunctions);
+    setGitEnvironmentVariables(extractedLambdaFunctions);
   }
 
   public addForwarderToNonLambdaLogGroups(logGroups: logs.ILogGroup[]) {
@@ -199,6 +198,19 @@ function grantReadLambdasFromSecretArn(construct: Construct, arn: string, lambda
   lambdaFunctions.forEach((functionName) => {
     secret.grantRead(functionName);
   });
+}
+
+function extractSingletonFunctions(lambdaFunctions: LambdaFunction[]) {
+  // extract lambdaFunction property from Singleton Function
+  // using any here since lambdaFunction is a private property
+  const extractedLambdaFunctions: lambda.Function[] = lambdaFunctions.map((fn: any) => {
+    if (fn.hasOwnProperty("lambdaFunction")) {
+      return fn.lambdaFunction;
+    }
+    return fn;
+  });
+
+  return extractedLambdaFunctions;
 }
 
 export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {

--- a/v2/src/interfaces.ts
+++ b/v2/src/interfaces.ts
@@ -6,6 +6,9 @@
  * Copyright 2021 Datadog, Inc.
  */
 
+import * as lambdaPython from "@aws-cdk/aws-lambda-python-alpha";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 
 export interface DatadogProps {
@@ -79,3 +82,9 @@ export interface Runtime {
 export interface Node {
   readonly defaultChild: any;
 }
+
+export type LambdaFunction =
+  | lambda.Function
+  | lambdaNodejs.NodejsFunction
+  | lambdaPython.PythonFunction
+  | lambda.SingletonFunction;

--- a/v2/test/index.spec.ts
+++ b/v2/test/index.spec.ts
@@ -34,6 +34,12 @@ describe("addLambdaFunctions", () => {
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
+    const singletonLambda = new lambda.SingletonFunction(stack, "SingletonHandler", {
+      runtime: lambda.Runtime.PYTHON_3_7,
+      code: lambda.Code.fromAsset("test"),
+      handler: "hello.handler",
+      uuid: "be308085-96c4-4208-9092-560d9d79e2c5",
+    });
     const datadogCdk = new Datadog(stack, "Datadog", {
       nodeLayerVersion: 20,
       pythonLayerVersion: 28,
@@ -46,11 +52,14 @@ describe("addLambdaFunctions", () => {
     });
     datadogCdk.addLambdaFunctions([nodeLambda]);
     datadogCdk.addLambdaFunctions([pythonLambda]);
+    datadogCdk.addLambdaFunctions([singletonLambda]);
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
+    const singletonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(singletonLambda);
     expect(nodeLambdaSubscriptionFilters).toHaveLength(1);
     expect(pythonLambdaSubscriptionFilters).toHaveLength(1);
+    expect(singletonLambdaSubscriptionFilters).toHaveLength(1);
     expect(nodeLambdaSubscriptionFilters[0].destinationArn).toEqual(pythonLambdaSubscriptionFilters[0].destinationArn);
   });
 

--- a/v2/test/test-utils.ts
+++ b/v2/test/test-utils.ts
@@ -3,7 +3,16 @@ import { Construct } from "constructs";
 import { SUBSCRIPTION_FILTER_PREFIX } from "../src/index";
 
 export const findDatadogSubscriptionFilters = (baseConstruct: Construct) => {
-  return baseConstruct.node
+  // extract lambdaFunction property from Singleton Function
+  // using any here since lambdaFunction is a private property
+  let baseConstructModified: Construct;
+  if (baseConstruct.hasOwnProperty("lambdaFunction")) {
+    baseConstructModified = (baseConstruct as any).lambdaFunction as Construct;
+  } else {
+    baseConstructModified = baseConstruct;
+  }
+
+  return baseConstructModified.node
     .findAll()
     .filter((construct) => construct.node.id.startsWith(SUBSCRIPTION_FILTER_PREFIX))
     .map((construct) => {

--- a/v2/test/test-utils.ts
+++ b/v2/test/test-utils.ts
@@ -1,13 +1,14 @@
+import * as lambda from "aws-cdk-lib/aws-lambda";
 import { CfnSubscriptionFilter } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 import { SUBSCRIPTION_FILTER_PREFIX } from "../src/index";
 
 export const findDatadogSubscriptionFilters = (baseConstruct: Construct) => {
   // extract lambdaFunction property from Singleton Function
-  // using any here since lambdaFunction is a private property
+  // using bracket notation here since lambdaFunction is a private property
   let baseConstructModified: Construct;
   if (baseConstruct.hasOwnProperty("lambdaFunction")) {
-    baseConstructModified = (baseConstruct as any).lambdaFunction as Construct;
+    baseConstructModified = (baseConstruct as lambda.SingletonFunction)["lambdaFunction"] as Construct; // eslint-disable-line dot-notation
   } else {
     baseConstructModified = baseConstruct;
   }

--- a/v2/test/test-utils.ts
+++ b/v2/test/test-utils.ts
@@ -6,12 +6,9 @@ import { SUBSCRIPTION_FILTER_PREFIX } from "../src/index";
 export const findDatadogSubscriptionFilters = (baseConstruct: Construct) => {
   // extract lambdaFunction property from Singleton Function
   // using bracket notation here since lambdaFunction is a private property
-  let baseConstructModified: Construct;
-  if (baseConstruct.hasOwnProperty("lambdaFunction")) {
-    baseConstructModified = (baseConstruct as lambda.SingletonFunction)["lambdaFunction"] as Construct; // eslint-disable-line dot-notation
-  } else {
-    baseConstructModified = baseConstruct;
-  }
+  const baseConstructModified: Construct = isSingletonFunction(baseConstruct)
+    ? baseConstruct["lambdaFunction"] // eslint-disable-line dot-notation
+    : baseConstruct;
 
   return baseConstructModified.node
     .findAll()
@@ -30,3 +27,7 @@ export const findDatadogSubscriptionFilters = (baseConstruct: Construct) => {
     })
     .reduce((acc, subscriptionFilters) => acc.concat(subscriptionFilters), []);
 };
+
+function isSingletonFunction(fn: Construct): fn is lambda.SingletonFunction {
+  return fn.hasOwnProperty("lambdaFunction");
+}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Adds support for Singleton functions.

### Motivation

https://datadoghq.atlassian.net/browse/SVLS-3474

### Testing Guidelines

* Added unit test to verify `addLambdaFunctions` handles Singleton functions as expected
* Added integration test for adding Datadog extension and layer to Singleton function
  * `./v2/scripts/run_integration_tests.sh` (with `UPDATE_SNAPSHOTS-true` to generate snapshot for singleton function)
* Tested manually in sandbox
  * `npx cdk --app lib/sample/index.js deploy`

### Additional Notes

The Lambda function in the SingletonFunction class is in the `lambdaFunction` property so before making any updates to Singleton functions the Lambda function is extracted from this `lambdaFunction` property.

* Updated `test-utils.findDatadogSubscriptionFilters` to properly handle Singleton functions in unit test
* Added singleton function handling to `datadog.addGitCommitMetadata` since it is also a public method along with `datadog.addLambdaFunctions`

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
