### PR TITLE
Bump CDK and @aws-cdk/aws-lambda-python-alpha to 2.93

### DIFF
--- a/v2/.projen/deps.json
+++ b/v2/.projen/deps.json
@@ -27,7 +27,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.71.0",
+      "version": "2.93.0",
       "type": "build"
     },
     {
@@ -133,7 +133,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.71.0",
+      "version": "^2.93.0",
       "type": "peer"
     },
     {

--- a/v2/.projen/deps.json
+++ b/v2/.projen/deps.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
-      "version": "2.63.0-alpha.0",
+      "version": "2.93.0-alpha.0",
       "type": "build"
     },
     {
@@ -128,7 +128,7 @@
     },
     {
       "name": "@aws-cdk/aws-lambda-python-alpha",
-      "version": "^2.63.0-alpha.0",
+      "version": "^2.93.0-alpha.0",
       "type": "peer"
     },
     {

--- a/v2/.projenrc.js
+++ b/v2/.projenrc.js
@@ -21,7 +21,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     module: "datadog_cdk_constructs_v2",
   },
   peerDeps: ["@aws-cdk/aws-lambda-python-alpha@^2.93.0-alpha.0"],
-  cdkVersion: "2.71.0",
+  cdkVersion: "2.93.0",
   deps: ["loglevel"],
   bundledDeps: ["loglevel"],
   devDeps: ["ts-node", "prettier", "eslint-config-prettier", "eslint-plugin-prettier", "standard-version"],

--- a/v2/.projenrc.js
+++ b/v2/.projenrc.js
@@ -20,7 +20,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     distName: "datadog-cdk-constructs-v2",
     module: "datadog_cdk_constructs_v2",
   },
-  peerDeps: ["@aws-cdk/aws-lambda-python-alpha@^2.63.0-alpha.0"],
+  peerDeps: ["@aws-cdk/aws-lambda-python-alpha@^2.93.0-alpha.0"],
   cdkVersion: "2.71.0",
   deps: ["loglevel"],
   bundledDeps: ["loglevel"],

--- a/v2/integration_tests/snapshots/correct-lambda-function-arm-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-function-arm-stack-snapshot.json
@@ -37,18 +37,12 @@
   "HelloHandlerXXXXXXXX": {
    "Type": "AWS::Lambda::Function",
    "Properties": {
-    "Code": {
-     "ZipFile": "test"
-    },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Architectures": [
      "arm64"
     ],
+    "Code": {
+     "ZipFile": "test"
+    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
@@ -67,6 +61,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:10"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -160,10 +160,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -177,9 +177,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -191,6 +188,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -290,14 +290,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -320,6 +314,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -397,17 +397,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -430,6 +421,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/correct-lambda-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-function-stack-snapshot.json
@@ -40,12 +40,6 @@
     "Code": {
      "ZipFile": "test"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
@@ -64,6 +58,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -157,10 +157,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -174,9 +174,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -188,6 +185,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -287,14 +287,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -317,6 +311,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -394,17 +394,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -427,6 +418,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-java-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
@@ -65,6 +59,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "java11",
     "Tags": [
      {
@@ -161,10 +161,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -178,9 +178,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -192,6 +189,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -291,14 +291,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -321,6 +315,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -398,17 +398,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -431,6 +422,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/correct-lambda-nodejs-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-nodejs-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
@@ -66,6 +60,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -162,10 +162,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -179,9 +179,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -193,6 +190,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -292,14 +292,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -322,6 +316,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -399,17 +399,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -432,6 +423,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/correct-lambda-python-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/correct-lambda-python-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "example-python.handler",
@@ -65,6 +59,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "python3.7",
     "Tags": [
      {
@@ -161,10 +161,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -178,9 +178,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -192,6 +189,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -291,14 +291,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -321,6 +315,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -398,17 +398,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -431,6 +422,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/test-lambda-function-arm-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-function-arm-stack-snapshot.json
@@ -37,18 +37,12 @@
   "HelloHandlerXXXXXXXX": {
    "Type": "AWS::Lambda::Function",
    "Properties": {
-    "Code": {
-     "ZipFile": "test"
-    },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Architectures": [
      "arm64"
     ],
+    "Code": {
+     "ZipFile": "test"
+    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
@@ -67,6 +61,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:10"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -160,10 +160,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -177,9 +177,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -191,6 +188,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -290,14 +290,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -320,6 +314,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -397,17 +397,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -430,6 +421,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/test-lambda-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-function-stack-snapshot.json
@@ -40,12 +40,6 @@
     "Code": {
      "ZipFile": "test"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
@@ -64,6 +58,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -157,10 +157,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -174,9 +174,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -188,6 +185,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -287,14 +287,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -317,6 +311,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -394,17 +394,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -427,6 +418,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-java-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "AWS_LAMBDA_EXEC_WRAPPER": "/opt/datadog_wrapper",
@@ -65,6 +59,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:dd-trace-java:5",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "java11",
     "Tags": [
      {
@@ -161,10 +161,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -178,9 +178,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -192,6 +189,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -291,14 +291,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -321,6 +315,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -398,17 +398,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -431,6 +422,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/test-lambda-nodejs-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-nodejs-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
@@ -66,6 +60,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "nodejs14.x",
     "Tags": [
      {
@@ -162,10 +162,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -179,9 +179,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -193,6 +190,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -292,14 +292,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -322,6 +316,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -399,17 +399,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -432,6 +423,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/integration_tests/snapshots/test-lambda-python-function-stack-snapshot.json
+++ b/v2/integration_tests/snapshots/test-lambda-python-function-stack-snapshot.json
@@ -41,12 +41,6 @@
      "S3Bucket": "cdk-hnb659fds-assets-601427279990-sa-east-1",
      "S3Key": "serverless/dd-cdk-construct-integration-test/dev/XXXXXXXXXXXXX-XXXX-XX-XXXXX:XX:XX.XXXX/dd-cdk-construct-integration-test.zip"
     },
-    "Role": {
-     "Fn::GetAtt": [
-      "HelloHandlerServiceRoleXXXXXXXX",
-      "Arn"
-     ]
-    },
     "Environment": {
      "Variables": {
       "DD_LAMBDA_HANDLER": "example-python.handler",
@@ -65,6 +59,12 @@
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Python37:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
     "Runtime": "python3.7",
     "Tags": [
      {
@@ -161,10 +161,10 @@
   "resttestDeploymentXXXXXXXX": {
    "Type": "AWS::ApiGateway::Deployment",
    "Properties": {
+    "Description": "Automatically created by the RestApi construct",
     "RestApiId": {
      "Ref": "resttestXXXXXXXX"
-    },
-    "Description": "Automatically created by the RestApi construct"
+    }
    },
    "DependsOn": [
     "resttestproxyANYXXXXXXXX",
@@ -178,9 +178,6 @@
   "resttestDeploymentStageprodXXXXXXXX": {
    "Type": "AWS::ApiGateway::Stage",
    "Properties": {
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AccessLogSetting": {
      "DestinationArn": {
       "Fn::GetAtt": [
@@ -192,6 +189,9 @@
     },
     "DeploymentId": {
      "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     },
     "StageName": "prod"
    },
@@ -291,14 +291,8 @@
   "resttestproxyANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Ref": "resttestproxyXXXXXXXX"
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -321,6 +315,12 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {
@@ -398,17 +398,8 @@
   "resttestANYXXXXXXXX": {
    "Type": "AWS::ApiGateway::Method",
    "Properties": {
-    "HttpMethod": "ANY",
-    "ResourceId": {
-     "Fn::GetAtt": [
-      "resttestXXXXXXXX",
-      "RootResourceId"
-     ]
-    },
-    "RestApiId": {
-     "Ref": "resttestXXXXXXXX"
-    },
     "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
     "Integration": {
      "IntegrationHttpMethod": "POST",
      "Type": "AWS_PROXY",
@@ -431,6 +422,15 @@
        ]
       ]
      }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
     }
    },
    "Metadata": {

--- a/v2/package.json
+++ b/v2/package.json
@@ -30,7 +30,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.63.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.93.0-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
@@ -57,7 +57,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.63.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.93.0-alpha.0",
     "aws-cdk-lib": "^2.71.0",
     "constructs": "^10.0.5"
   },

--- a/v2/package.json
+++ b/v2/package.json
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.4",
+  "version": "0.0.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/package.json
+++ b/v2/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.71.0",
+    "aws-cdk-lib": "2.93.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.6.0",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "^2.93.0-alpha.0",
-    "aws-cdk-lib": "^2.71.0",
+    "aws-cdk-lib": "^2.93.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "version": "1.7.4",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/yarn.lock
+++ b/v2/yarn.lock
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.99.tgz#dad2c6b6a54ffe968b0290eb5c4ab154c775ef22"
   integrity sha512-Z4JY9HZBwAyry7Tjhstxi5CJEDW5gpa7rkXBsXH2sf5f7NrVSJWVCI8fSiLppfxl+T4QKV1xU/s3I8XcS8jw7w==
 
-"@aws-cdk/aws-lambda-python-alpha@2.63.0-alpha.0":
-  version "2.63.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.63.0-alpha.0.tgz#6db70edbbf92af0fb19a57357ecdf8ef41e078c2"
-  integrity sha512-UZnzCHXa3BcM4cebs/i4k5khMYCtUTkJztJwo/lI2sAyRGJHKGP2yzxrNp5DS6YygWsUZddDATyjj32azHBEig==
+"@aws-cdk/aws-lambda-python-alpha@2.93.0-alpha.0":
+  version "2.93.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.93.0-alpha.0.tgz#f84bc18c7de44b4ee9059d544e63e80cfe688063"
+  integrity sha512-h/vclUQ0dlGF+T6j41UA2rxn1r9udZ35CT7F/L9MzRUssj09ihybhZhK1YvI8r1K7h0Ozwj1+1zVbhqD7A9E8g==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"

--- a/v2/yarn.lock
+++ b/v2/yarn.lock
@@ -10,20 +10,20 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.97":
-  version "2.2.122"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.122.tgz#d80dd44dc7d4ae12f42f44ee44b0bb8ac9c5d67e"
-  integrity sha512-SgftgtNpuLyBh8iYP+IaliVVvn4u8E6h6wakLrzycIeb3aiy6kusLH+AtQ0N1o3OYKMjr2IzuNLJaMLQfLX9PA==
+"@aws-cdk/asset-awscli-v1@^2.2.200":
+  version "2.2.200"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz#6ead533f73f705ad7350eb46955e2538e50cd013"
+  integrity sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==
 
-"@aws-cdk/asset-kubectl-v20@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
-  integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
+"@aws-cdk/asset-kubectl-v20@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz#d8e20b5f5dc20128ea2000dc479ca3c7ddc27248"
+  integrity sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.77":
-  version "2.0.99"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.99.tgz#dad2c6b6a54ffe968b0290eb5c4ab154c775ef22"
-  integrity sha512-Z4JY9HZBwAyry7Tjhstxi5CJEDW5gpa7rkXBsXH2sf5f7NrVSJWVCI8fSiLppfxl+T4QKV1xU/s3I8XcS8jw7w==
+"@aws-cdk/asset-node-proxy-agent-v6@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz#6dc9b7cdb22ff622a7176141197962360c33e9ac"
+  integrity sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==
 
 "@aws-cdk/aws-lambda-python-alpha@2.93.0-alpha.0":
   version "2.93.0-alpha.0"
@@ -1285,22 +1285,22 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.71.0:
-  version "2.71.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.71.0.tgz#7a8516bfb4f3242c8b4aa7e2406bdaaba6429b1a"
-  integrity sha512-YHAeClmsv7EbXpwPIKIBWO1aOp6VdvQFPp+7P1pQMgOz9kKiMO+B/m9g74iKscICEYmbHlZJ8T2KduHxObqIQw==
+aws-cdk-lib@2.93.0:
+  version "2.93.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.93.0.tgz#545bc0072bc0f2e27cb0fecb0c9e54de29b10731"
+  integrity sha512-kKbcKkts272Ju5xjGKI3pXTOpiJxW4OQbDF8Vmw/NIkkuJLo8GlRCFfeOfoN/hilvlYQgENA67GCgSWccbvu7w==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.97"
-    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.77"
+    "@aws-cdk/asset-awscli-v1" "^2.2.200"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.2"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^9.1.0"
+    fs-extra "^11.1.1"
     ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.3.0"
-    semver "^7.3.8"
+    semver "^7.5.4"
     table "^6.8.1"
     yaml "1.10.2"
 
@@ -2688,6 +2688,15 @@ fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -5524,6 +5533,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What does this PR do?
Bumps CDK version to 2.93

Snapshots needed to be regenerated but AFAICT only the order of keys in the json changed

### Motivation
https://github.com/DataDog/datadog-cdk-constructs/issues/208

### Testing Guidelines
Deployed with testing app

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
