### PR TITLE
feat: ASM for Lambda configuration

### DIFF
--- a/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
+++ b/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
@@ -32,12 +32,13 @@ export class TypescriptV2Stack extends Stack {
     console.log("Instrumenting with Datadog");
 
     const DatadogCDK = new Datadog(this as any, "Datadog", {
-      nodeLayerVersion: 87,
-      pythonLayerVersion: 69,
-      extensionLayerVersion: 41,
+      nodeLayerVersion: 98,
+      pythonLayerVersion: 80,
+      extensionLayerVersion: 49,
       addLayers: true,
       apiKey: process.env.DD_API_KEY,
       enableDatadogTracing: true,
+      enableDatadogASM: true,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
     });

--- a/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
+++ b/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Function } from "aws-cdk-lib/aws-lambda";
+import * as aws_apigateway from "aws-cdk-lib/aws-apigateway";
 
 import { Datadog } from "datadog-cdk-constructs-v2";
 import { Stack, StackProps } from "aws-cdk-lib";
@@ -27,6 +28,16 @@ export class TypescriptV2Stack extends Stack {
       runtime: lambda.Runtime.PYTHON_3_7,
       code: lambda.Code.fromAsset("lambda"),
       handler: "hello_py.lambda_handler",
+    });
+
+    const apig = new aws_apigateway.RestApi(this, "RestAPI").root;
+    apig.addResource('node').addProxy({
+      anyMethod: true,
+      defaultIntegration: new aws_apigateway.LambdaIntegration(helloNode),
+    });
+    apig.addResource('python').addProxy({
+      anyMethod: true,
+      defaultIntegration: new aws_apigateway.LambdaIntegration(helloPython),
     });
 
     console.log("Instrumenting with Datadog");

--- a/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
+++ b/examples/typescript-cdk-v2/lib/typescript_v2-stack.ts
@@ -2,7 +2,7 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Function } from "aws-cdk-lib/aws-lambda";
-import * as aws_apigateway from "aws-cdk-lib/aws-apigateway";
+import * as apigateway from "aws-cdk-lib/aws-apigateway";
 
 import { Datadog } from "datadog-cdk-constructs-v2";
 import { Stack, StackProps } from "aws-cdk-lib";
@@ -30,14 +30,14 @@ export class TypescriptV2Stack extends Stack {
       handler: "hello_py.lambda_handler",
     });
 
-    const apig = new aws_apigateway.RestApi(this, "RestAPI").root;
+    const apig = new apigateway.RestApi(this, "RestAPI").root;
     apig.addResource('node').addProxy({
       anyMethod: true,
-      defaultIntegration: new aws_apigateway.LambdaIntegration(helloNode),
+      defaultIntegration: new apigateway.LambdaIntegration(helloNode),
     });
     apig.addResource('python').addProxy({
       anyMethod: true,
-      defaultIntegration: new aws_apigateway.LambdaIntegration(helloPython),
+      defaultIntegration: new apigateway.LambdaIntegration(helloPython),
     });
 
     console.log("Instrumenting with Datadog");

--- a/examples/typescript-cdk-v2/package.json
+++ b/examples/typescript-cdk-v2/package.json
@@ -23,7 +23,7 @@
     "@aws-cdk/aws-lambda-python-alpha": "^2.70.0-alpha.0",
     "aws-cdk-lib": "2.70.0",
     "constructs": "^10.0.0",
-    "datadog-cdk-constructs-v2": "^1.2.0",
+    "datadog-cdk-constructs-v2": "^1.8.0",
     "source-map-support": "^0.5.21"
   }
 }

--- a/examples/typescript-cdk-v2/yarn.lock
+++ b/examples/typescript-cdk-v2/yarn.lock
@@ -1052,12 +1052,12 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-datadog-cdk-constructs-v2@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/datadog-cdk-constructs-v2/-/datadog-cdk-constructs-v2-1.2.0.tgz"
-  integrity sha512-HL1jxlXg5wQGufFCJceUn4NSToNgRfvCIqwSo/fmEFsbKjqOobAT5PxxJ72GY5y3kFJSIG++tO4eOiceZ4fhwQ==
+datadog-cdk-constructs-v2@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/datadog-cdk-constructs-v2/-/datadog-cdk-constructs-v2-1.8.0.tgz#218b4f49e8091dd557e99188d91006eb89daa14c"
+  integrity sha512-j5Txef0knxKm4GhNKBtyZIOyvKNafYdhput4aL0aoeoidI3/R03krH8G/Pav/oAbnWZY0ODD62suyJCWcCqp1A==
   dependencies:
-    loglevel "^1.8.0"
+    loglevel "^1.8.1"
 
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
@@ -1830,7 +1830,7 @@ lodash.memoize@4.x:
   resolved "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
   integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
-loglevel@^1.8.0:
+loglevel@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
   integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==

--- a/v2/src/constants.ts
+++ b/v2/src/constants.ts
@@ -28,6 +28,7 @@ export enum RuntimeType {
 export const DefaultDatadogProps = {
   addLayers: true,
   enableDatadogTracing: true,
+  enableDatadogApplicationSecurity: false,
   enableMergeXrayTraces: false,
   injectLogContext: true,
   enableDatadogLogs: true,

--- a/v2/src/constants.ts
+++ b/v2/src/constants.ts
@@ -28,7 +28,7 @@ export enum RuntimeType {
 export const DefaultDatadogProps = {
   addLayers: true,
   enableDatadogTracing: true,
-  enableDatadogApplicationSecurity: false,
+  enableDatadogASM: false,
   enableMergeXrayTraces: false,
   injectLogContext: true,
   enableDatadogLogs: true,

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -259,8 +259,8 @@ export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {
       throw new Error("When `extensionLayer` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");
     }
   }
-  if (props.enableDatadogTracing === false && props.enableDatadogApplicationSecurity === true) {
-    throw new Error("When `enableDatadogApplicationSecurity` is enabled, `enableDatadogTracing` must also be enabled.");
+  if (props.enableDatadogTracing === false && props.enableDatadogASM === true) {
+    throw new Error("When `enableDatadogASM` is enabled, `enableDatadogTracing` must also be enabled.");
   }
 }
 
@@ -285,7 +285,7 @@ export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride =
 export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictProps {
   let addLayers = props.addLayers;
   let enableDatadogTracing = props.enableDatadogTracing;
-  let enableDatadogApplicationSecurity = props.enableDatadogApplicationSecurity;
+  let enableDatadogASM = props.enableDatadogASM;
   let enableMergeXrayTraces = props.enableMergeXrayTraces;
   let injectLogContext = props.injectLogContext;
   const logLevel = props.logLevel;
@@ -304,11 +304,9 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
     log.debug(`No value provided for enableDatadogTracing, defaulting to ${DefaultDatadogProps.enableDatadogTracing}`);
     enableDatadogTracing = DefaultDatadogProps.enableDatadogTracing;
   }
-  if (enableDatadogApplicationSecurity === undefined) {
-    log.debug(
-      `No value provided for enableDatadogApplicationSecurity, defaulting to ${DefaultDatadogProps.enableDatadogApplicationSecurity}`,
-    );
-    enableDatadogApplicationSecurity = DefaultDatadogProps.enableDatadogApplicationSecurity;
+  if (enableDatadogASM === undefined) {
+    log.debug(`No value provided for enableDatadogASM, defaulting to ${DefaultDatadogProps.enableDatadogASM}`);
+    enableDatadogASM = DefaultDatadogProps.enableDatadogASM;
   }
   if (enableMergeXrayTraces === undefined) {
     log.debug(
@@ -349,7 +347,7 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
   return {
     addLayers: addLayers,
     enableDatadogTracing: enableDatadogTracing,
-    enableDatadogApplicationSecurity,
+    enableDatadogASM,
     enableMergeXrayTraces: enableMergeXrayTraces,
     injectLogContext: injectLogContext,
     logLevel: logLevel,

--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -259,6 +259,9 @@ export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {
       throw new Error("When `extensionLayer` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");
     }
   }
+  if (props.enableDatadogTracing === false && props.enableDatadogApplicationSecurity === true) {
+    throw new Error("When `enableDatadogApplicationSecurity` is enabled, `enableDatadogTracing` must also be enabled.");
+  }
 }
 
 export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride = false) {
@@ -282,6 +285,7 @@ export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride =
 export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictProps {
   let addLayers = props.addLayers;
   let enableDatadogTracing = props.enableDatadogTracing;
+  let enableDatadogApplicationSecurity = props.enableDatadogApplicationSecurity;
   let enableMergeXrayTraces = props.enableMergeXrayTraces;
   let injectLogContext = props.injectLogContext;
   const logLevel = props.logLevel;
@@ -299,6 +303,12 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
   if (enableDatadogTracing === undefined) {
     log.debug(`No value provided for enableDatadogTracing, defaulting to ${DefaultDatadogProps.enableDatadogTracing}`);
     enableDatadogTracing = DefaultDatadogProps.enableDatadogTracing;
+  }
+  if (enableDatadogApplicationSecurity === undefined) {
+    log.debug(
+      `No value provided for enableDatadogApplicationSecurity, defaulting to ${DefaultDatadogProps.enableDatadogApplicationSecurity}`,
+    );
+    enableDatadogApplicationSecurity = DefaultDatadogProps.enableDatadogApplicationSecurity;
   }
   if (enableMergeXrayTraces === undefined) {
     log.debug(
@@ -339,6 +349,7 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
   return {
     addLayers: addLayers,
     enableDatadogTracing: enableDatadogTracing,
+    enableDatadogApplicationSecurity,
     enableMergeXrayTraces: enableMergeXrayTraces,
     injectLogContext: injectLogContext,
     logLevel: logLevel,

--- a/v2/src/env.ts
+++ b/v2/src/env.ts
@@ -11,7 +11,7 @@ import log from "loglevel";
 import { DatadogProps, DatadogStrictProps } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
-export const ENABLE_DD_APPSEC_ENV_VAR = "DD_APPSEC_ENABLED";
+export const ENABLE_DD_ASM_ENV_VAR = "DD_APPSEC_ENABLED";
 export const ENABLE_XRAY_TRACE_MERGING_ENV_VAR = "DD_MERGE_XRAY_TRACES";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
 export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL";
@@ -99,7 +99,7 @@ export function applyEnvVariables(lambdas: lambda.Function[], baseProps: Datadog
   log.debug(`Setting environment variables...`);
   lambdas.forEach((lam) => {
     lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
-    lam.addEnvironment(ENABLE_DD_APPSEC_ENV_VAR, baseProps.enableDatadogApplicationSecurity.toString().toLowerCase());
+    lam.addEnvironment(ENABLE_DD_ASM_ENV_VAR, baseProps.enableDatadogASM.toString().toLowerCase());
     lam.addEnvironment(ENABLE_XRAY_TRACE_MERGING_ENV_VAR, baseProps.enableMergeXrayTraces.toString().toLowerCase());
     // Check for extensionLayerVersion and set INJECT_LOG_CONTEXT_ENV_VAR accordingly
     if (baseProps.extensionLayerVersion) {

--- a/v2/src/env.ts
+++ b/v2/src/env.ts
@@ -11,6 +11,7 @@ import log from "loglevel";
 import { DatadogProps, DatadogStrictProps } from "./interfaces";
 
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
+export const ENABLE_DD_APPSEC_ENV_VAR = "DD_APPSEC_ENABLED";
 export const ENABLE_XRAY_TRACE_MERGING_ENV_VAR = "DD_MERGE_XRAY_TRACES";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
 export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL";
@@ -98,6 +99,7 @@ export function applyEnvVariables(lambdas: lambda.Function[], baseProps: Datadog
   log.debug(`Setting environment variables...`);
   lambdas.forEach((lam) => {
     lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
+    lam.addEnvironment(ENABLE_DD_APPSEC_ENV_VAR, baseProps.enableDatadogApplicationSecurity.toString().toLowerCase());
     lam.addEnvironment(ENABLE_XRAY_TRACE_MERGING_ENV_VAR, baseProps.enableMergeXrayTraces.toString().toLowerCase());
     // Check for extensionLayerVersion and set INJECT_LOG_CONTEXT_ENV_VAR accordingly
     if (baseProps.extensionLayerVersion) {

--- a/v2/src/env.ts
+++ b/v2/src/env.ts
@@ -10,8 +10,11 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import log from "loglevel";
 import { DatadogProps, DatadogStrictProps } from "./interfaces";
 
+export const AWS_LAMBDA_EXEC_WRAPPER_KEY = "AWS_LAMBDA_EXEC_WRAPPER";
+export const AWS_LAMBDA_EXEC_WRAPPER_VAL = "/opt/datadog_wrapper";
+
 export const ENABLE_DD_TRACING_ENV_VAR = "DD_TRACE_ENABLED";
-export const ENABLE_DD_ASM_ENV_VAR = "DD_APPSEC_ENABLED";
+export const ENABLE_DD_ASM_ENV_VAR = "DD_SERVERLESS_APPSEC_ENABLED";
 export const ENABLE_XRAY_TRACE_MERGING_ENV_VAR = "DD_MERGE_XRAY_TRACES";
 export const INJECT_LOG_CONTEXT_ENV_VAR = "DD_LOGS_INJECTION";
 export const LOG_LEVEL_ENV_VAR = "DD_LOG_LEVEL";
@@ -100,6 +103,10 @@ export function applyEnvVariables(lambdas: lambda.Function[], baseProps: Datadog
   lambdas.forEach((lam) => {
     lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
     lam.addEnvironment(ENABLE_DD_ASM_ENV_VAR, baseProps.enableDatadogASM.toString().toLowerCase());
+    if (baseProps.enableDatadogASM) {
+      lam.addEnvironment(AWS_LAMBDA_EXEC_WRAPPER_KEY, AWS_LAMBDA_EXEC_WRAPPER_VAL);
+    }
+
     lam.addEnvironment(ENABLE_XRAY_TRACE_MERGING_ENV_VAR, baseProps.enableMergeXrayTraces.toString().toLowerCase());
     // Check for extensionLayerVersion and set INJECT_LOG_CONTEXT_ENV_VAR accordingly
     if (baseProps.extensionLayerVersion) {

--- a/v2/src/interfaces.ts
+++ b/v2/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface DatadogProps {
   readonly apiKeySecret?: secrets.ISecret;
   readonly apiKmsKey?: string;
   readonly enableDatadogTracing?: boolean;
+  readonly enableDatadogApplicationSecurity?: boolean;
   readonly enableMergeXrayTraces?: boolean;
   readonly injectLogContext?: boolean;
   readonly logLevel?: string;
@@ -57,6 +58,7 @@ export interface DatadogStrictProps {
   readonly captureLambdaPayload: boolean;
   readonly injectLogContext: boolean;
   readonly enableDatadogTracing: boolean;
+  readonly enableDatadogApplicationSecurity: boolean;
   readonly enableMergeXrayTraces: boolean;
   readonly grantSecretReadAccess: boolean;
   readonly pythonLayerVersion?: number;

--- a/v2/src/interfaces.ts
+++ b/v2/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface DatadogProps {
   readonly apiKeySecret?: secrets.ISecret;
   readonly apiKmsKey?: string;
   readonly enableDatadogTracing?: boolean;
-  readonly enableDatadogApplicationSecurity?: boolean;
+  readonly enableDatadogASM?: boolean;
   readonly enableMergeXrayTraces?: boolean;
   readonly injectLogContext?: boolean;
   readonly logLevel?: string;
@@ -58,7 +58,7 @@ export interface DatadogStrictProps {
   readonly captureLambdaPayload: boolean;
   readonly injectLogContext: boolean;
   readonly enableDatadogTracing: boolean;
-  readonly enableDatadogApplicationSecurity: boolean;
+  readonly enableDatadogASM: boolean;
   readonly enableMergeXrayTraces: boolean;
   readonly grantSecretReadAccess: boolean;
   readonly pythonLayerVersion?: number;

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -214,7 +214,7 @@ describe("validateProps", () => {
     );
   });
 
-  it("throws an error if enableDatadogApplicationSecurity is enabled and enableDatadogTracing is not", () => {
+  it("throws an error if enableDatadogASM is enabled and enableDatadogTracing is not", () => {
     const app = new App();
     const stack = new Stack(app, "stack", {
       env: {
@@ -225,9 +225,9 @@ describe("validateProps", () => {
       () =>
         new Datadog(stack, "Datadog", {
           enableDatadogTracing: false,
-          enableDatadogApplicationSecurity: true,
+          enableDatadogASM: true,
         }),
-    ).toThrow("When `enableDatadogApplicationSecurity` is enabled, `enableDatadogTracing` must also be enabled.");
+    ).toThrow("When `enableDatadogASM` is enabled, `enableDatadogTracing` must also be enabled.");
   });
 });
 

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -213,6 +213,22 @@ describe("validateProps", () => {
       "When `extensionLayer` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.",
     );
   });
+
+  it("throws an error if enableDatadogApplicationSecurity is enabled and enableDatadogTracing is not", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    expect(
+      () =>
+        new Datadog(stack, "Datadog", {
+          enableDatadogTracing: false,
+          enableDatadogApplicationSecurity: true,
+        }),
+    ).toThrow("When `enableDatadogApplicationSecurity` is enabled, `enableDatadogTracing` must also be enabled.");
+  });
 });
 
 describe("addCdkConstructVersionTag", () => {

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -106,7 +106,7 @@ describe("applyEnvVariables", () => {
       handler: "hello.handler",
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
-      enableDatadogApplicationSecurity: true,
+      enableDatadogASM: true,
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -82,7 +82,7 @@ describe("applyEnvVariables", () => {
           ["DD_LAMBDA_HANDLER"]: "hello.handler",
           ["DD_FLUSH_TO_LOG"]: "true",
           ["DD_TRACE_ENABLED"]: "true",
-          ["DD_APPSEC_ENABLED"]: "false",
+          ["DD_SERVERLESS_APPSEC_ENABLED"]: "false",
           ["DD_MERGE_XRAY_TRACES"]: "false",
           ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
           ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",
@@ -112,10 +112,11 @@ describe("applyEnvVariables", () => {
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Environment: {
         Variables: {
+          ["AWS_LAMBDA_EXEC_WRAPPER"]: "/opt/datadog_wrapper",
           ["DD_LAMBDA_HANDLER"]: "hello.handler",
           ["DD_FLUSH_TO_LOG"]: "true",
           ["DD_TRACE_ENABLED"]: "true",
-          ["DD_APPSEC_ENABLED"]: "true",
+          ["DD_SERVERLESS_APPSEC_ENABLED"]: "true",
           ["DD_MERGE_XRAY_TRACES"]: "false",
           ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
           ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -82,11 +82,44 @@ describe("applyEnvVariables", () => {
           ["DD_LAMBDA_HANDLER"]: "hello.handler",
           ["DD_FLUSH_TO_LOG"]: "true",
           ["DD_TRACE_ENABLED"]: "true",
+          ["DD_APPSEC_ENABLED"]: "false",
           ["DD_MERGE_XRAY_TRACES"]: "false",
           ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
           ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",
           ["DD_LOGS_INJECTION"]: "true",
           ["DD_LOG_LEVEL"]: "debug",
+        },
+      },
+    });
+  });
+
+  it("correctly enables AppSec", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_12_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogCDK = new Datadog(stack, "Datadog", {
+      enableDatadogApplicationSecurity: true,
+    });
+    datadogCDK.addLambdaFunctions([hello]);
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Environment: {
+        Variables: {
+          ["DD_LAMBDA_HANDLER"]: "hello.handler",
+          ["DD_FLUSH_TO_LOG"]: "true",
+          ["DD_TRACE_ENABLED"]: "true",
+          ["DD_APPSEC_ENABLED"]: "true",
+          ["DD_MERGE_XRAY_TRACES"]: "false",
+          ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
+          ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",
+          ["DD_LOGS_INJECTION"]: "true",
         },
       },
     });


### PR DESCRIPTION
### What does this PR do?

Adds support to configure the ASM product for Lamdba functions by injecting the relevant environment variable. Note that ASM can only be enabled if tracing is also enabled; failure to do so results in a validation error.

### Motivation

It makes it easier to onboard AppSec for Lambda and reduces the risk of misconfiguration.

### Testing Guidelines

Unit tests were added for the new features.

### Types of Changes

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [X] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [X] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
