### PR TITLE
chore(deps): upgrade `aws-cdk` libraries to `v2.110.1`

### DIFF
--- a/examples/python-stack/README.md
+++ b/examples/python-stack/README.md
@@ -8,7 +8,7 @@ Use this example Python stack to try out the [datadog-cdk-constructs](https://gi
 1. Run `export DD_API_KEY=<DATADOG_API_KEY>` to set the Datadog API key in your shell session.
 1. Run `virtualenv env` to create a virtual environment.
 1. Run `source env/bin/activate` to activate the virtual environment.
-1. Run `pip install -r requirements` install dependencies.
+1. Run `pip install -r requirements.txt` install dependencies.
 1. Update the layer versions in [cdk_python/cdk_python_stack.py](https://github.com/DataDog/datadog-cdk-constructs/blob/d2f1f60b7e0594ae77dd76a7f5964bee651e8022/examples/python-stack/cdk_python/cdk_python_stack.py#L72-L74) with the latest releases:
    - Datadog Lambda Extension: https://github.com/DataDog/datadog-lambda-extension/releases
    - Python Layer: https://github.com/DataDog/datadog-lambda-python/releases

--- a/examples/python-stack/cdk_python/cdk_python_stack.py
+++ b/examples/python-stack/cdk_python/cdk_python_stack.py
@@ -19,12 +19,12 @@ class CdkPythonStack(Stack):
         hello_node = _lambda.Function(
             self,
             "hello-node",
-            runtime=_lambda.Runtime.NODEJS_18_X,
+            runtime=_lambda.Runtime.NODEJS_20_X,
             timeout=Duration.seconds(10),
             code=_lambda.Code.from_asset(
                 "../lambda/node",
                 bundling=BundlingOptions(
-                    image=_lambda.Runtime.NODEJS_18_X.bundling_image,
+                    image=_lambda.Runtime.NODEJS_20_X.bundling_image,
                     command=[
                         "bash",
                         "-c",
@@ -69,9 +69,9 @@ class CdkPythonStack(Stack):
         datadog = Datadog(
             self,
             "Datadog",
-            node_layer_version=99,
-            python_layer_version=81,
-            extension_layer_version=49,
+            node_layer_version=100,
+            python_layer_version=83,
+            extension_layer_version=51,
             add_layers=True,
             api_key=os.getenv("DD_API_KEY"),
             enable_datadog_tracing=True,

--- a/examples/python-stack/requirements.txt
+++ b/examples/python-stack/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib~=2.101.1
-aws-cdk.aws-lambda-go-alpha~=2.101.1a0
+aws-cdk-lib~=2.110.1
+aws-cdk.aws-lambda-go-alpha~=2.110.1a0
 constructs~=10.0.5
 datadog_cdk_constructs_v2~=1.9.0

--- a/examples/typescript-stack/lib/cdk-typescript-stack.ts
+++ b/examples/typescript-stack/lib/cdk-typescript-stack.ts
@@ -12,11 +12,11 @@ export class CdkTypeScriptStack extends Stack {
     console.log("Creating Hello World TypeScript stack");
 
     const helloNode = new Function(this, "hello-node", {
-      runtime: lambda.Runtime.NODEJS_18_X,
+      runtime: lambda.Runtime.NODEJS_20_X,
       timeout: Duration.seconds(10),
       code: lambda.Code.fromAsset("../lambda/node", {
         bundling: {
-          image: lambda.Runtime.NODEJS_18_X.bundlingImage,
+          image: lambda.Runtime.NODEJS_20_X.bundlingImage,
           command: [
             "bash",
             "-c",
@@ -63,9 +63,9 @@ export class CdkTypeScriptStack extends Stack {
     );
 
     const DatadogCDK = new Datadog(this, "Datadog", {
-      nodeLayerVersion: 99,
-      pythonLayerVersion: 81,
-      extensionLayerVersion: 49,
+      nodeLayerVersion: 100,
+      pythonLayerVersion: 83,
+      extensionLayerVersion: 51,
       addLayers: true,
       apiKey: process.env.DD_API_KEY,
       enableDatadogTracing: true,

--- a/examples/typescript-stack/package.json
+++ b/examples/typescript-stack/package.json
@@ -6,14 +6,14 @@
   },
   "devDependencies": {
     "@types/node": "^20.8.8",
-    "aws-cdk": "^2.102.0",
+    "aws-cdk": "^2.110.1",
     "ts-node": "^10.9.1",
     "typescript": "~5.2.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-go-alpha": "^2.101.0-alpha.0",
-    "@aws-cdk/aws-lambda-python-alpha": "^2.102.0-alpha.0",
-    "aws-cdk-lib": "^2.102.0",
+    "@aws-cdk/aws-lambda-go-alpha": "^2.110.1-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.110.1-alpha.0",
+    "aws-cdk-lib": "^2.110.1",
     "constructs": "^10.3.0",
     "datadog-cdk-constructs-v2": "^1.9.0"
   }

--- a/examples/typescript-stack/yarn.lock
+++ b/examples/typescript-stack/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/asset-awscli-v1@^2.2.200":
-  version "2.2.200"
-  resolved "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz"
-  integrity sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==
+"@aws-cdk/asset-awscli-v1@^2.2.201":
+  version "2.2.201"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz#a7b51d3ecc8ff3ca9798269eda3a1db2400b506a"
+  integrity sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.2":
   version "2.1.2"
@@ -17,15 +17,15 @@
   resolved "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz"
   integrity sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==
 
-"@aws-cdk/aws-lambda-go-alpha@^2.101.0-alpha.0":
-  version "2.101.0-alpha.0"
-  resolved "https://registry.npmjs.org/@aws-cdk/aws-lambda-go-alpha/-/aws-lambda-go-alpha-2.101.0-alpha.0.tgz"
-  integrity sha512-pENSsL0LaJ957UltgLrTvMCPe2YwRVI7gRjU2ktm0tF3fg12N/fYRS9zzXHgqK4WIH3QSVlOozaUkVOYMwPirg==
+"@aws-cdk/aws-lambda-go-alpha@^2.110.1-alpha.0":
+  version "2.110.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-go-alpha/-/aws-lambda-go-alpha-2.110.1-alpha.0.tgz#fbc82337a4397d31d7787eda27d9d2bbbd9e8629"
+  integrity sha512-Q+fHdAolqAyN5TxYnOTQaGmKdfJ6w8r4cQ+8P56eN29jEwa20CsjaqlUNAH1YerpQknlmCijj9MUT3GWc9bZfw==
 
-"@aws-cdk/aws-lambda-python-alpha@^2.102.0-alpha.0":
-  version "2.102.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.102.0-alpha.0.tgz#20f6145e8c99ee70254be79d74c6c401df980ea0"
-  integrity sha512-Or0w7lecc4ioLDXyE2e3DKbPKCeFj+lZnHMY3sHkYXR8Fiy+xyWrULi+Nrg8q8KI19lD6QT5mKZ3jAgjysKvlw==
+"@aws-cdk/aws-lambda-python-alpha@^2.110.1-alpha.0":
+  version "2.110.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.110.1-alpha.0.tgz#2acefb32b1cda6fb1a19b26f0c8ffb8daabd8273"
+  integrity sha512-kOg/2VqIr0UIGSjjM+8SzWYeFW5kmgI8INrlghUmRQ/ov1XfBxxEQoy/LlDWMtiHW1W9oLaUv525OUQ5XTMnnQ==
 
 "@balena/dockerignore@^1.0.2":
   version "1.0.2"
@@ -126,12 +126,12 @@ astral-regex@^2.0.0:
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-aws-cdk-lib@^2.102.0:
-  version "2.102.0"
-  resolved "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.102.0.tgz"
-  integrity sha512-pYcKGlshU2j7n3f8TbJ1CCrwNnLsgGd17G7p/s9njIU8xakU4tIwuNyo4Q9HHQA7aUb3enPI/afAn1A6gp7TrA==
+aws-cdk-lib@^2.110.1:
+  version "2.110.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.110.1.tgz#3bbe61ec03b73da390ae5718060385c26333749d"
+  integrity sha512-Z+42Jc/KSKFdBOpEv4LK9tz6kQUdVvUBquIYhLajam3aGblkonM0/FgexvAqy8iGwUaVEIpVyBTZUP2/VUMalg==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.200"
+    "@aws-cdk/asset-awscli-v1" "^2.2.201"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
@@ -140,15 +140,15 @@ aws-cdk-lib@^2.102.0:
     ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.3.0"
+    punycode "^2.3.1"
     semver "^7.5.4"
     table "^6.8.1"
     yaml "1.10.2"
 
-aws-cdk@^2.102.0:
-  version "2.102.0"
-  resolved "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.102.0.tgz"
-  integrity sha512-q+FQSeX/25QvZ1/Fxjr7GydMY/WR/+iTif2EiaN7rUlEEZx27o0I5k1p9YmTNUGiBl13ZvggIJjwTRmnL7E/lg==
+aws-cdk@^2.110.1:
+  version "2.110.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-2.110.1.tgz#d7fee94aa311b163993c4a1febc7cf4a4b66206b"
+  integrity sha512-/V0FOgsvD/FkFANrYnSmyb+XK56tm2oE86pUCoEggQ2tka6Zm0z9blKZQV4euMErNSkWz4ReSAKenaqk86Fr5Q==
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -296,10 +296,15 @@ minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-punycode@^2.1.0, punycode@^2.3.0:
+punycode@^2.1.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 require-from-string@^2.0.2:
   version "2.0.2"

--- a/v2/package.json
+++ b/v2/package.json
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "1.9.0",
+  "version": "0.0.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/package.json
+++ b/v2/package.json
@@ -30,12 +30,12 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "2.101.1-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.110.1-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.101.1",
+    "aws-cdk-lib": "^2.110.1",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.6.0",
@@ -57,8 +57,8 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-lambda-python-alpha": "^2.101.1-alpha.0",
-    "aws-cdk-lib": "^2.101.1",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.110.1-alpha.0",
+    "aws-cdk-lib": "^2.110.1",
     "constructs": "^10.0.5"
   },
   "dependencies": {
@@ -75,7 +75,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "version": "0.0.0",
+  "version": "1.9.0",
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",

--- a/v2/yarn.lock
+++ b/v2/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.200":
-  version "2.2.200"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.200.tgz#6ead533f73f705ad7350eb46955e2538e50cd013"
-  integrity sha512-Kf5J8DfJK4wZFWT2Myca0lhwke7LwHcHBo+4TvWOGJrFVVKVuuiLCkzPPRBQQVDj0Vtn2NBokZAz8pfMpAqAKg==
+"@aws-cdk/asset-awscli-v1@^2.2.201":
+  version "2.2.201"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz#a7b51d3ecc8ff3ca9798269eda3a1db2400b506a"
+  integrity sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==
 
 "@aws-cdk/asset-kubectl-v20@^2.1.2":
   version "2.1.2"
@@ -25,10 +25,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz#6dc9b7cdb22ff622a7176141197962360c33e9ac"
   integrity sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==
 
-"@aws-cdk/aws-lambda-python-alpha@2.101.1-alpha.0":
-  version "2.101.1-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.101.1-alpha.0.tgz#5b11824e2a8d3efe27580a6db95b33023e9a3fc0"
-  integrity sha512-g7T4C6a9ouHVEMCOiMnYqIVI3NZLXxdc10686Fhc5BGB88Yim5cuKQw3UF753KJB9GGTSMe++YSgmIqhPqOztw==
+"@aws-cdk/aws-lambda-python-alpha@2.110.1-alpha.0":
+  version "2.110.1-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.110.1-alpha.0.tgz#2acefb32b1cda6fb1a19b26f0c8ffb8daabd8273"
+  integrity sha512-kOg/2VqIr0UIGSjjM+8SzWYeFW5kmgI8INrlghUmRQ/ov1XfBxxEQoy/LlDWMtiHW1W9oLaUv525OUQ5XTMnnQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -1285,12 +1285,12 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.101.1:
-  version "2.101.1"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.101.1.tgz#cd096f2cf57f5ddd446d4b271cb7717b2b0d9322"
-  integrity sha512-kKrJ0CcD82IyohjB3TRy34whf22GI6Y2bIrkBmui+fCb2t13+ToJb7zKBRmL6C090OsoiU/q+H6/WIZWOoYDvQ==
+aws-cdk-lib@^2.110.1:
+  version "2.110.1"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.110.1.tgz#3bbe61ec03b73da390ae5718060385c26333749d"
+  integrity sha512-Z+42Jc/KSKFdBOpEv4LK9tz6kQUdVvUBquIYhLajam3aGblkonM0/FgexvAqy8iGwUaVEIpVyBTZUP2/VUMalg==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.200"
+    "@aws-cdk/asset-awscli-v1" "^2.2.201"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
@@ -1299,7 +1299,7 @@ aws-cdk-lib@2.101.1:
     ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.3.0"
+    punycode "^2.3.1"
     semver "^7.5.4"
     table "^6.8.1"
     yaml "1.10.2"
@@ -5189,10 +5189,15 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.0:
+punycode@^2.1.0, punycode@^2.1.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
   integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
+
+punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 pupa@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Upgrades `aws-cdk` and related dependencies to latest version.

### Motivation

Node 20 runtime is added in latest version, so our examples need it.

### Testing Guidelines

n/a

### Additional Notes

Upgraded examples to use Node 20 runtime for Node functions in both stacks.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
