### PR TITLE
chore: remove `integration_tests` from packaging

### DIFF
--- a/v2/.npmignore
+++ b/v2/.npmignore
@@ -3,6 +3,7 @@
 !LICENSE-3rdparty.csv
 !NOTICE
 /scripts
+/integration_tests
 .prettierrc
 cdk.out/*
 yarn-error.log

--- a/v2/.projenrc.js
+++ b/v2/.projenrc.js
@@ -43,6 +43,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "!LICENSE-3rdparty.csv",
     "!NOTICE",
     "/scripts",
+    "/integration_tests",
     ".prettierrc",
     "cdk.out/*",
     "yarn-error.log",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

We were packaging `integration_tests`.

### Motivation

This is bad because it cause some dependencies to be peer dependencies.
Relevant to #227

### Testing Guidelines

Checked that the package was not present in the `tgz` for Node and Python builds.

### Additional Notes

n/a

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
