### PR TITLE
fix: Ensure ASM does not apply when the extension is not present

### DIFF
--- a/v2/src/datadog.ts
+++ b/v2/src/datadog.ts
@@ -260,8 +260,13 @@ export function validateProps(props: DatadogProps, apiKeyArnOverride = false) {
       throw new Error("When `extensionLayer` is set, `apiKey`, `apiKeySecretArn`, or `apiKmsKey` must also be set.");
     }
   }
-  if (props.enableDatadogTracing === false && props.enableDatadogASM === true) {
-    throw new Error("When `enableDatadogASM` is enabled, `enableDatadogTracing` must also be enabled.");
+  if (
+    (props.enableDatadogTracing === false && props.enableDatadogASM) ||
+    (props.extensionLayerVersion == undefined && props.enableDatadogASM)
+  ) {
+    throw new Error(
+      "When `enableDatadogASM` is enabled, `enableDatadogTracing` and `extensionLayerVersion` must also be enabled.",
+    );
   }
 }
 

--- a/v2/test/datadog.spec.ts
+++ b/v2/test/datadog.spec.ts
@@ -227,7 +227,26 @@ describe("validateProps", () => {
           enableDatadogTracing: false,
           enableDatadogASM: true,
         }),
-    ).toThrow("When `enableDatadogASM` is enabled, `enableDatadogTracing` must also be enabled.");
+    ).toThrow(
+      "When `enableDatadogASM` is enabled, `enableDatadogTracing` and `extensionLayerVersion` must also be enabled.",
+    );
+  });
+
+  it("throws an error if enableDatadogASM is enabled and extensionLayerVersion is not", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "sa-east-1",
+      },
+    });
+    expect(
+      () =>
+        new Datadog(stack, "Datadog", {
+          enableDatadogASM: true,
+        }),
+    ).toThrow(
+      "When `enableDatadogASM` is enabled, `enableDatadogTracing` and `extensionLayerVersion` must also be enabled.",
+    );
   });
 });
 

--- a/v2/test/env.spec.ts
+++ b/v2/test/env.spec.ts
@@ -107,6 +107,8 @@ describe("applyEnvVariables", () => {
     });
     const datadogCDK = new Datadog(stack, "Datadog", {
       enableDatadogASM: true,
+      extensionLayerVersion: 50,
+      apiKey: "test",
     });
     datadogCDK.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
@@ -114,13 +116,11 @@ describe("applyEnvVariables", () => {
         Variables: {
           ["AWS_LAMBDA_EXEC_WRAPPER"]: "/opt/datadog_wrapper",
           ["DD_LAMBDA_HANDLER"]: "hello.handler",
-          ["DD_FLUSH_TO_LOG"]: "true",
           ["DD_TRACE_ENABLED"]: "true",
           ["DD_SERVERLESS_APPSEC_ENABLED"]: "true",
           ["DD_MERGE_XRAY_TRACES"]: "false",
           ["DD_SERVERLESS_LOGS_ENABLED"]: "true",
           ["DD_CAPTURE_LAMBDA_PAYLOAD"]: "false",
-          ["DD_LOGS_INJECTION"]: "true",
         },
       },
     });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
We identified and fixed a similar issue in the serverless plugin where ASM config may inadvertently be applied to functions without the extension configured.
This would cause those functions to crash.

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
