### PR TITLE
fix: Fix module name for Go

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -21,7 +21,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     module: "datadog_cdk_constructs_v2",
   },
   publishToGo: {
-    moduleName: "github.com/DataDog/datadog-cdk-constructs",
+    moduleName: "github.com/DataDog/datadog-cdk-constructs/dist/go",
     packageName: "ddcdkconstruct",
   },
   peerDeps: [],

--- a/dist/go/ddcdkconstruct/Datadog.go
+++ b/dist/go/ddcdkconstruct/Datadog.go
@@ -2,11 +2,11 @@ package ddcdkconstruct
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/DataDog/datadog-cdk-constructs/ddcdkconstruct/jsii"
+	_init_ "github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct/jsii"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslogs"
 	"github.com/aws/constructs-go/constructs/v10"
-	"github.com/DataDog/datadog-cdk-constructs/ddcdkconstruct/internal"
+	"github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct/internal"
 )
 
 type Datadog interface {

--- a/dist/go/ddcdkconstruct/Transport.go
+++ b/dist/go/ddcdkconstruct/Transport.go
@@ -2,7 +2,7 @@ package ddcdkconstruct
 
 import (
 	_jsii_ "github.com/aws/jsii-runtime-go/runtime"
-	_init_ "github.com/DataDog/datadog-cdk-constructs/ddcdkconstruct/jsii"
+	_init_ "github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct/jsii"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 )

--- a/dist/go/ddcdkconstruct/go.mod
+++ b/dist/go/ddcdkconstruct/go.mod
@@ -1,4 +1,4 @@
-module github.com/DataDog/datadog-cdk-constructs/ddcdkconstruct
+module github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct
 
 go 1.18
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
         "module": "datadog_cdk_constructs_v2"
       },
       "go": {
-        "moduleName": "github.com/DataDog/datadog-cdk-constructs",
+        "moduleName": "github.com/DataDog/datadog-cdk-constructs/dist/go",
         "packageName": "ddcdkconstruct"
       }
     },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

Right now the Go module name configured is wrong. It doesn't include the path inside the directory: `dist/go`. As a result, in a Go project, when I tried to install this package, I got an error:
```
yiming.luo@COMP-J7WRL6274T go-hello % go get -u github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct
go: github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct@upgrade (v0.0.0-20240731210442-cae5a5626d82) requires github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct@v0.0.0-20240731210442-cae5a5626d82: parsing go.mod:
	module declares its path as: github.com/DataDog/datadog-cdk-constructs/ddcdkconstruct
	        but was required as: github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct
```
<!--- What inspired you to submit this pull request? --->

### What does this PR do?

Fix this error by adding `dist/go` to the module name.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Steps
1. Push this commit to a new branch `yiming.luo/support-golang`
2. In the Go project, install the package from the new branch:
```
yiming.luo@COMP-J7WRL6274T go-hello % go get -u github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct@yiming.luo/support-golang
go: downloading github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct v0.0.0-20240731215958-5319883dbd9d
go: added github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct v0.0.0-20240731215958-5319883dbd9d
go: added github.com/Masterminds/semver/v3 v3.2.1
go: added github.com/aws/aws-cdk-go/awscdk/v2 v2.150.0
go: added github.com/aws/constructs-go/constructs/v10 v10.3.0
go: added github.com/aws/jsii-runtime-go v1.101.0
go: added github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.202
go: added github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2
go: added github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.0.3
```
#### Result
As shown above, the package was found and installed successfully.
<!--- How did you test this pull request? --->

### Additional Notes
After the package is installed, there are still some errors when I try to use the package in the Go app. I'd like to test again after this PR is merged to main.
<!--- Anything else we should know when reviewing? --->

Related Feature Request: [Datadog CDK Construct for Go](https://datadoghq.atlassian.net/browse/FRSLES-665)
### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
