### PR TITLE
fix: Add Go construct .tgz file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,5 @@ tsconfig.json
 !integration_tests/tsconfig.json
 dist/*
 !dist/go
+!dist/go/ddcdkconstruct/jsii/*.tgz
 !/.projenrc.js

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -114,7 +114,9 @@ project.gitignore.removePatterns("/dist/");
 // The two lines below makes git track "dist/go" and ignore all other folders
 // under "dist/"
 project.gitignore.addPatterns("dist/*");
-project.gitignore.include("!dist/go");
+project.gitignore.include("dist/go");
+
+project.gitignore.include("dist/go/ddcdkconstruct/jsii/*.tgz");
 
 // Collapse the generated Go package on GitHub
 project.gitattributes.addAttributes("/dist/go/** linguist-generated");


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

1. Make git track `datadog-cdk-constructs-v2-1.13.0.tgz`, which is for the Go construct
2. Add this file

<!--- A brief description of the change being made with this pull request. --->

### Motivation

In a AWS CDK Go project, after I run this command to install the Datadog Go construct:
```
go get -u github.com/DataDog/datadog-cdk-constructs/dist/go/ddcdkconstruct
```
the package and dependencies are downloaded successfully. However, in the app code, IDE raises an error:
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/ac119409-d861-46df-baca-03effd61eca8">
It says this `.tgz` file is missing. This file was actually generated in my local copy of `datadog-cdk-constructs` repo. However, it is not tracked by git, thus unable to be downloaded by the CDK user.

By checking some examples from AWS (e.g. [Amazon Lambda Golang Library](https://github.com/aws/aws-cdk-go/tree/main/awscdklambdagoalpha/jsii)), we see that it's a common practice to make git track the `.tgz` file for a Go CDK construct.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Manually copy the `.tgz` file to the directory where Go packages are placed. Then the error is gone from IDE.
<img width="736" alt="image" src="https://github.com/user-attachments/assets/1d0df630-d46c-4fdd-977a-232eb6b1d175">

Adding this file to git will achieve the same result.

<!--- How did you test this pull request? --->

### Additional Notes
Next steps:
1. try to use the package in the Go CDK
2. Update `README.md`, adding instructions
3. Think how future updates will affect the `.tgz` file and whether it will break things
4. *Maybe release a new version and write a release note

[Feature Request: Datadog CDK Construct for Go](https://datadoghq.atlassian.net/browse/FRSLES-665)

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
