### PR TITLE
chore: add script to make pkg.go.dev pick up new version

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -125,6 +125,10 @@ python3 -m twine upload -u __token__ ./dist/python/*
 echo "Publishing the Go package to datadog-cdk-constructs-go GitHub repo"
 read -p "Please enter your GitHub username: " GITHUB_TOKEN
 GITHUB_TOKEN=$GITHUB_TOKEN npx -p publib@latest publib-golang
+echo "Making pkg.go.dev pick up the new version from GitHub"
+# Note: the URL must be in lower case. Any upper case letter (like in "DataDog") would cause 
+# an error like: "bad request: invalid escaped module path "github.com/DataDog/datadog-cdk-constructs-go/ddcdkconstruct""
+curl https://proxy.golang.org/github.com/datadog/datadog-cdk-constructs-go/ddcdkconstruct/@v/v$VERSION.info
 
 echo 'Pushing updates to github'
 git push origin main


### PR DESCRIPTION


<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Problem
After a new version of the Go package is published, pkg.go.dev won't pick up the new version immediately. For example, after I released version 1.14.0 to repo `datadog-cdk-construct-go`, [pkg.go.dev](https://pkg.go.dev/github.com/DataDog/datadog-cdk-constructs-go/ddcdkconstruct) still showed 1.13.0 as the latest version.
<!--- What inspired you to submit this pull request? --->

### What does this PR do?
Make `publish_prod.sh` script make an explicit request to `proxy.golang.org` so they can pick up the latest version.
Refer to: https://pkg.go.dev/about#adding-a-package


<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
This time I'm unable to test that it works because I already notified pkg.go.dev in another way, i.e. visiting https://pkg.go.dev/github.com/DataDog/datadog-cdk-constructs-go/ddcdkconstruct@v1.14.0 then clicking the Request button, which is the first way mentioned in https://pkg.go.dev/about#adding-a-package.

However I can test that the command can run without error:
```
yiming.luo@COMP-J7WRL6274T datadog-cdk-constructs % VERSION='1.14.0'                                                                                           
yiming.luo@COMP-J7WRL6274T datadog-cdk-constructs % curl https://proxy.golang.org/github.com/datadog/datadog-cdk-constructs-go/ddcdkconstruct/@v/v$VERSION.info
{"Version":"v1.14.0","Time":"2024-08-13T20:28:55Z","Origin":{"VCS":"git","URL":"https://github.com/datadog/datadog-cdk-constructs-go","Subdir":"ddcdkconstruct","Hash":"e43af4f7c380f592d23406230980e9aaeec85be2","Ref":"refs/tags/ddcdkconstruct/v1.14.0"}}%      
```

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
