### PR TITLE
chore: fix some code style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -216,6 +216,7 @@
         ]
       }
     ],
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-empty-interface": "off",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -86,6 +86,7 @@ eslintConfig.addOverride("extends", [
 ]);
 
 eslintConfig.addOverride("rules", {
+  "@typescript-eslint/switch-exhaustiveness-check": "error",
   "@typescript-eslint/no-require-imports": "off",
   "@typescript-eslint/no-var-requires": "off",
   "@typescript-eslint/no-explicit-any": "off",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -34,7 +34,6 @@ export const DefaultDatadogProps = {
   enableMergeXrayTraces: false,
   injectLogContext: true,
   enableDatadogLogs: true,
-  architecture: "X86_64",
   captureLambdaPayload: false,
   sourceCodeIntegration: true,
   redirectHandler: true,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Make some fixes around code style
1. remove an unused const
2. change an if-else block to switch-case, and add a lint rule "switch-exhaustiveness-check", so that if a new value is added to `RuntimeType` some day, the switch-case will become non-exhaustive and lint will remind us to handle the new value in the switch case
```
export enum RuntimeType {
  DOTNET,
  NODE,
  PYTHON,
  JAVA,
  CUSTOM,
  UNSUPPORTED,
}
```
3. change
```
if (condition) {
  /* lots of code */ 
}
```
to 
```
if (!condition) {
  return;
}
// lots of code
```
to make code more readable.

See comments on code for more.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

`npx projen build` finishes successfully.

To test the link exhaustive check, I removed
```
      case RuntimeType.CUSTOM:
        break;
```
from the switch-case block, then run `npx projen build`. I got an error as expected:
<img width="759" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/5804b0b6-48c3-4152-8bd5-b7ff77d8428e">


<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
