### PR TITLE
fix: add custom provided.al2023 to runtime lookup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,6 +69,7 @@ export const runtimeLookup: { [key: string]: RuntimeType } = {
   "java21": RuntimeType.JAVA,
   "provided": RuntimeType.CUSTOM,
   "provided.al2": RuntimeType.CUSTOM,
+  "provided.al2023": RuntimeType.CUSTOM,
 };
 
 export const runtimeToLayerName: { [key: string]: string } = {


### PR DESCRIPTION
### What does this PR do?

Adds support for `provided.al2023` in the Lambda runtime lookup.

### Motivation

To fix issue https://github.com/DataDog/datadog-cdk-constructs/issues/282

### Testing Guidelines

npm test

### Additional Notes

See notes on the issue https://github.com/DataDog/datadog-cdk-constructs/issues/282

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
