### PR TITLE
chore: auto format some TypeScript files

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -28,7 +28,7 @@
       "name": "check-formatting",
       "steps": [
         {
-          "exec": "prettier --check src/**"
+          "exec": "prettier --check src/** integration_tests/**/*.ts examples/**/*.ts"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -67,7 +67,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "CONTRIBUTING.md",
   ],
   scripts: {
-    "check-formatting": "prettier --check src/**",
+    "check-formatting": "prettier --check src/** integration_tests/**/*.ts examples/**/*.ts",
   },
   pullRequestTemplate: false,
   dependabot: false,

--- a/examples/typescript-stack/lib/cdk-typescript-stack.ts
+++ b/examples/typescript-stack/lib/cdk-typescript-stack.ts
@@ -20,11 +20,7 @@ export class CdkTypeScriptStack extends Stack {
       code: lambda.Code.fromAsset("../lambda/node", {
         bundling: {
           image: lambda.Runtime.NODEJS_20_X.bundlingImage,
-          command: [
-            "bash",
-            "-c",
-            "cp -aT . /asset-output && npm install --prefix /asset-output",
-          ],
+          command: ["bash", "-c", "cp -aT . /asset-output && npm install --prefix /asset-output"],
           user: "root",
         },
       }),
@@ -38,11 +34,7 @@ export class CdkTypeScriptStack extends Stack {
       code: lambda.Code.fromAsset("../lambda/python", {
         bundling: {
           image: lambda.Runtime.PYTHON_3_12.bundlingImage,
-          command: [
-            "bash",
-            "-c",
-            "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output",
-          ],
+          command: ["bash", "-c", "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output"],
         },
       }),
       handler: "hello.lambda_handler",
@@ -66,33 +58,31 @@ export class CdkTypeScriptStack extends Stack {
       runtime: lambda.Runtime.DOTNET_8,
       handler: "HelloWorld::HelloWorld.Handler::SayHi",
       memorySize: 256,
-      code: lambda.Code.fromAsset('../lambda/dotnet/', {
+      code: lambda.Code.fromAsset("../lambda/dotnet/", {
         bundling: {
           image: lambda.Runtime.DOTNET_8.bundlingImage,
           command: [
-            '/bin/sh',
-            '-c',
-            ' dotnet tool install -g Amazon.Lambda.Tools' +
-            ' && dotnet build' +
-            ' && dotnet lambda package --output-package /asset-output/function.zip'
+            "/bin/sh",
+            "-c",
+            " dotnet tool install -g Amazon.Lambda.Tools" +
+              " && dotnet build" +
+              " && dotnet lambda package --output-package /asset-output/function.zip",
           ],
-          user: 'root',
-          outputType: BundlingOutput.ARCHIVED
-        }
-      })
-    })
-
-    const dotnetHttpIntegration = new HttpLambdaIntegration('GetDotnetIntegration', helloDotnet);
-    const dotnetHttpApi = new apigwv2.HttpApi(this, "dotnetHttpApi")
-    dotnetHttpApi.addRoutes({
-      path: '/hello',
-      methods: [ apigwv2.HttpMethod.GET ],
-      integration:  dotnetHttpIntegration
+          user: "root",
+          outputType: BundlingOutput.ARCHIVED,
+        },
+      }),
     });
 
-    console.log(
-      "Instrumenting Lambda Functions in TypeScript stack with Datadog"
-    );
+    const dotnetHttpIntegration = new HttpLambdaIntegration("GetDotnetIntegration", helloDotnet);
+    const dotnetHttpApi = new apigwv2.HttpApi(this, "dotnetHttpApi");
+    dotnetHttpApi.addRoutes({
+      path: "/hello",
+      methods: [apigwv2.HttpMethod.GET],
+      integration: dotnetHttpIntegration,
+    });
+
+    console.log("Instrumenting Lambda Functions in TypeScript stack with Datadog");
 
     const DatadogCDK = new Datadog(this, "Datadog", {
       dotnetLayerVersion: 15,

--- a/integration_tests/lambda/example-lambda.ts
+++ b/integration_tests/lambda/example-lambda.ts
@@ -1,4 +1,3 @@
 export const handler = (): void => {
-    return;
+  return;
 };
-  

--- a/integration_tests/stacks/lambda-function-arm-stack.ts
+++ b/integration_tests/stacks/lambda-function-arm-stack.ts
@@ -7,7 +7,7 @@
  */
 
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Datadog } from "../../src/index";
@@ -21,7 +21,7 @@ export class ExampleStack extends Stack {
       runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromInline("test"),
       handler: "lambdaFunction.handler",
-      architecture: Architecture.ARM_64
+      architecture: Architecture.ARM_64,
     });
 
     const restLogGroup = new LogGroup(this, "restLogGroup");

--- a/integration_tests/stacks/lambda-function-stack.ts
+++ b/integration_tests/stacks/lambda-function-stack.ts
@@ -7,7 +7,7 @@
  */
 
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Datadog } from "../../src/index";
@@ -29,7 +29,7 @@ export class ExampleStack extends Stack {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-  
+
     const datadogCDK = new Datadog(this, "Datadog", {
       nodeLayerVersion: 62,
       extensionLayerVersion: 10,

--- a/integration_tests/stacks/lambda-java-function-stack.ts
+++ b/integration_tests/stacks/lambda-java-function-stack.ts
@@ -9,7 +9,7 @@
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { Datadog } from "../../src/index";
 
 export class ExampleStack extends Stack {

--- a/integration_tests/stacks/lambda-nodejs-function-stack.ts
+++ b/integration_tests/stacks/lambda-nodejs-function-stack.ts
@@ -10,7 +10,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { Datadog } from "../../src/index";
 
 export class ExampleStack extends Stack {

--- a/integration_tests/stacks/lambda-python-function-stack.ts
+++ b/integration_tests/stacks/lambda-python-function-stack.ts
@@ -10,7 +10,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { PythonFunction } from "@aws-cdk/aws-lambda-python-alpha";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { Datadog } from "../../src/index";
 
 export class ExampleStack extends Stack {

--- a/integration_tests/stacks/lambda-singleton-function-stack.ts
+++ b/integration_tests/stacks/lambda-singleton-function-stack.ts
@@ -7,7 +7,7 @@
  */
 
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { Stack, StackProps, App } from "aws-cdk-lib"
+import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Datadog } from "../../src/index";
@@ -20,7 +20,7 @@ export class ExampleStack extends Stack {
       runtime: lambda.Runtime.NODEJS_14_X,
       code: lambda.Code.fromInline("test"),
       handler: "lambdaFunction.handler",
-      "uuid": "b55587fe-6985-4c28-ab51-4d0edb1ba8a1"
+      uuid: "b55587fe-6985-4c28-ab51-4d0edb1ba8a1",
     });
 
     const restLogGroup = new LogGroup(this, "restLogGroup");
@@ -30,7 +30,7 @@ export class ExampleStack extends Stack {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-  
+
     const datadogCDK = new Datadog(this, "Datadog", {
       nodeLayerVersion: 62,
       extensionLayerVersion: 10,


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Auto format some TypeScript files

### Motivation

<!--- What inspired you to submit this pull request? --->

The next PR (https://github.com/DataDog/datadog-cdk-constructs/pull/285) will touch lots of files, and saving those files on VS Code on my laptop will auto-format those files, mixing formatting changes and other changes in the same PR, so I want to separate out the formatting changes to this PR to make changes easier to review.

I can also disable "format on save" on my IDE, but I think it's a good thing to keep code in good format.

### Testing Guidelines

`npx projen build`, no error

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
