### PR TITLE
chore: rename Lambda related interfaces

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,7 +27,7 @@ export enum RuntimeType {
   UNSUPPORTED,
 }
 
-export const DefaultDatadogProps = {
+export const DatadogLambdaDefaultProps = {
   addLayers: true,
   enableDatadogTracing: true,
   enableDatadogASM: false,

--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -19,11 +19,11 @@ import {
   addForwarderToLogGroups,
   applyEnvVariables,
   TagKeys,
-  DatadogStrictProps,
+  DatadogLambdaStrictProps,
   setGitEnvironmentVariables,
   setDDEnvVariables,
-  DefaultDatadogProps,
-  DatadogProps,
+  DatadogLambdaDefaultProps,
+  DatadogLambdaProps,
   Transport,
 } from "./index";
 import { LambdaFunction } from "./interfaces";
@@ -32,10 +32,10 @@ const versionJson = require("../version.json");
 
 export class DatadogLambda extends Construct {
   scope: Construct;
-  props: DatadogProps;
+  props: DatadogLambdaProps;
   transport: Transport;
-  constructor(scope: Construct, id: string, props: DatadogProps) {
-    if (process.env.DD_CONSTRUCT_DEBUG_LOGS?.toLowerCase() == "true") {
+  constructor(scope: Construct, id: string, props: DatadogLambdaProps) {
+    if (process.env.DD_CONSTRUCT_DEBUG_LOGS?.toLowerCase() === "true") {
       log.setLevel("debug");
     }
     super(scope, id);
@@ -58,8 +58,8 @@ export class DatadogLambda extends Construct {
 
   public addLambdaFunctions(lambdaFunctions: LambdaFunction[], construct?: Construct): void {
     // baseProps contains all properties set by the user, with default values for properties
-    // defined in DefaultDatadogProps (if not set by user)
-    const baseProps: DatadogStrictProps = handleSettingPropDefaults(this.props);
+    // defined in DatadogLambdaDefaultProps (if not set by user)
+    const baseProps: DatadogLambdaStrictProps = handleSettingPropDefaults(this.props);
 
     const extractedLambdaFunctions = extractSingletonFunctions(lambdaFunctions);
 
@@ -160,7 +160,7 @@ export function addCdkConstructVersionTag(lambdaFunctions: lambda.Function[]): v
   });
 }
 
-function setTags(lambdaFunctions: lambda.Function[], props: DatadogProps): void {
+function setTags(lambdaFunctions: lambda.Function[], props: DatadogLambdaProps): void {
   log.debug(`Adding datadog tags`);
   lambdaFunctions.forEach((functionName) => {
     if (props.forwarderArn) {
@@ -214,7 +214,7 @@ function isSingletonFunction(fn: LambdaFunction): fn is lambda.SingletonFunction
   return fn.hasOwnProperty("lambdaFunction");
 }
 
-export function validateProps(props: DatadogProps, apiKeyArnOverride = false): void {
+export function validateProps(props: DatadogLambdaProps, apiKeyArnOverride = false): void {
   log.debug("Validating props...");
 
   checkForMultipleApiKeys(props, apiKeyArnOverride);
@@ -268,7 +268,7 @@ export function validateProps(props: DatadogProps, apiKeyArnOverride = false): v
   }
 }
 
-export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride = false): void {
+export function checkForMultipleApiKeys(props: DatadogLambdaProps, apiKeyArnOverride = false): void {
   let multipleApiKeysMessage;
   const apiKeyArnOrOverride = props.apiKeySecretArn !== undefined || apiKeyArnOverride;
   if (props.apiKey !== undefined && props.apiKmsKey !== undefined && apiKeyArnOrOverride) {
@@ -286,7 +286,7 @@ export function checkForMultipleApiKeys(props: DatadogProps, apiKeyArnOverride =
   }
 }
 
-export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictProps {
+export function handleSettingPropDefaults(props: DatadogLambdaProps): DatadogLambdaStrictProps {
   let addLayers = props.addLayers;
   let enableDatadogTracing = props.enableDatadogTracing;
   let enableDatadogASM = props.enableDatadogASM;
@@ -301,51 +301,59 @@ export function handleSettingPropDefaults(props: DatadogProps): DatadogStrictPro
   const extensionLayerVersion = props.extensionLayerVersion;
 
   if (addLayers === undefined) {
-    log.debug(`No value provided for addLayers, defaulting to ${DefaultDatadogProps.addLayers}`);
-    addLayers = DefaultDatadogProps.addLayers;
+    log.debug(`No value provided for addLayers, defaulting to ${DatadogLambdaDefaultProps.addLayers}`);
+    addLayers = DatadogLambdaDefaultProps.addLayers;
   }
   if (enableDatadogTracing === undefined) {
-    log.debug(`No value provided for enableDatadogTracing, defaulting to ${DefaultDatadogProps.enableDatadogTracing}`);
-    enableDatadogTracing = DefaultDatadogProps.enableDatadogTracing;
+    log.debug(
+      `No value provided for enableDatadogTracing, defaulting to ${DatadogLambdaDefaultProps.enableDatadogTracing}`,
+    );
+    enableDatadogTracing = DatadogLambdaDefaultProps.enableDatadogTracing;
   }
   if (enableDatadogASM === undefined) {
-    log.debug(`No value provided for enableDatadogASM, defaulting to ${DefaultDatadogProps.enableDatadogASM}`);
-    enableDatadogASM = DefaultDatadogProps.enableDatadogASM;
+    log.debug(`No value provided for enableDatadogASM, defaulting to ${DatadogLambdaDefaultProps.enableDatadogASM}`);
+    enableDatadogASM = DatadogLambdaDefaultProps.enableDatadogASM;
   }
   if (enableMergeXrayTraces === undefined) {
     log.debug(
-      `No value provided for enableMergeXrayTraces, defaulting to ${DefaultDatadogProps.enableMergeXrayTraces}`,
+      `No value provided for enableMergeXrayTraces, defaulting to ${DatadogLambdaDefaultProps.enableMergeXrayTraces}`,
     );
-    enableMergeXrayTraces = DefaultDatadogProps.enableMergeXrayTraces;
+    enableMergeXrayTraces = DatadogLambdaDefaultProps.enableMergeXrayTraces;
   }
   if (injectLogContext === undefined) {
-    log.debug(`No value provided for injectLogContext, defaulting to ${DefaultDatadogProps.injectLogContext}`);
-    injectLogContext = DefaultDatadogProps.injectLogContext;
+    log.debug(`No value provided for injectLogContext, defaulting to ${DatadogLambdaDefaultProps.injectLogContext}`);
+    injectLogContext = DatadogLambdaDefaultProps.injectLogContext;
   }
   if (logLevel === undefined) {
     log.debug(`No value provided for logLevel`);
   }
   if (enableDatadogLogs === undefined) {
-    log.debug(`No value provided for enableDatadogLogs, defaulting to ${DefaultDatadogProps.enableDatadogLogs}`);
-    enableDatadogLogs = DefaultDatadogProps.enableDatadogLogs;
+    log.debug(`No value provided for enableDatadogLogs, defaulting to ${DatadogLambdaDefaultProps.enableDatadogLogs}`);
+    enableDatadogLogs = DatadogLambdaDefaultProps.enableDatadogLogs;
   }
   if (captureLambdaPayload === undefined) {
-    log.debug(`No value provided for captureLambdaPayload, default to ${DefaultDatadogProps.captureLambdaPayload}`);
-    captureLambdaPayload = DefaultDatadogProps.captureLambdaPayload;
+    log.debug(
+      `No value provided for captureLambdaPayload, default to ${DatadogLambdaDefaultProps.captureLambdaPayload}`,
+    );
+    captureLambdaPayload = DatadogLambdaDefaultProps.captureLambdaPayload;
   }
   if (sourceCodeIntegration === undefined) {
-    log.debug(`No value provided for sourceCodeIntegration, default to ${DefaultDatadogProps.sourceCodeIntegration}`);
-    sourceCodeIntegration = DefaultDatadogProps.sourceCodeIntegration;
+    log.debug(
+      `No value provided for sourceCodeIntegration, default to ${DatadogLambdaDefaultProps.sourceCodeIntegration}`,
+    );
+    sourceCodeIntegration = DatadogLambdaDefaultProps.sourceCodeIntegration;
   }
 
   if (redirectHandler === undefined) {
-    log.debug(`No value provided for redirectHandler, default to ${DefaultDatadogProps.redirectHandler}`);
-    redirectHandler = DefaultDatadogProps.redirectHandler;
+    log.debug(`No value provided for redirectHandler, default to ${DatadogLambdaDefaultProps.redirectHandler}`);
+    redirectHandler = DatadogLambdaDefaultProps.redirectHandler;
   }
 
   if (grantSecretReadAccess === undefined) {
-    log.debug(`No value provided for grantSecretReadAccess, default to ${DefaultDatadogProps.grantSecretReadAccess}`);
-    grantSecretReadAccess = DefaultDatadogProps.grantSecretReadAccess;
+    log.debug(
+      `No value provided for grantSecretReadAccess, default to ${DatadogLambdaDefaultProps.grantSecretReadAccess}`,
+    );
+    grantSecretReadAccess = DatadogLambdaDefaultProps.grantSecretReadAccess;
   }
 
   return {

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -1,3 +1,8 @@
 import { DatadogLambda } from "./datadog-lambda";
 
+/**
+ * For backward compatibility. To be deprecated.
+ * It's recommended to use DatadogLambda for users who want to add Datadog
+ * monitoring for Lambda functions.
+ */
 export class Datadog extends DatadogLambda {}

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,7 +8,7 @@
 
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import log from "loglevel";
-import { DatadogProps, DatadogStrictProps } from "./interfaces";
+import { DatadogLambdaProps, DatadogLambdaStrictProps } from "./interfaces";
 
 export const AWS_LAMBDA_EXEC_WRAPPER_KEY = "AWS_LAMBDA_EXEC_WRAPPER";
 export const AWS_LAMBDA_EXEC_WRAPPER_VAL = "/opt/datadog_wrapper";
@@ -98,7 +98,7 @@ function filterSensitiveInfoFromRepository(repositoryUrl: string): string {
   }
 }
 
-export function applyEnvVariables(lambdas: lambda.Function[], baseProps: DatadogStrictProps): void {
+export function applyEnvVariables(lambdas: lambda.Function[], baseProps: DatadogLambdaStrictProps): void {
   log.debug(`Setting environment variables...`);
   lambdas.forEach((lam) => {
     lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
@@ -122,7 +122,7 @@ export function applyEnvVariables(lambdas: lambda.Function[], baseProps: Datadog
   });
 }
 
-export function setDDEnvVariables(lambdas: lambda.Function[], props: DatadogProps): void {
+export function setDDEnvVariables(lambdas: lambda.Function[], props: DatadogLambdaProps): void {
   lambdas.forEach((lam) => {
     if (props.extensionLayerVersion) {
       if (props.env) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as secrets from "aws-cdk-lib/aws-secretsmanager";
 
-export interface DatadogProps {
+export interface DatadogLambdaProps {
   readonly dotnetLayerVersion?: number;
   readonly pythonLayerVersion?: number;
   readonly nodeLayerVersion?: number;
@@ -48,10 +48,16 @@ export interface DatadogProps {
   readonly useLayersFromAccount?: string;
 }
 
-/*
- * Makes fields shared with DefaultDatadogProps (in constants file) required.
+/**
+ * For backward compatibility. It's recommended to use DatadogLambdaProps for
+ * users who want to add Datadog monitoring for Lambda functions.
  */
-export interface DatadogStrictProps {
+export type DatadogProps = DatadogLambdaProps;
+
+/*
+ * Makes fields shared with DatadogLambdaDefaultProps (in constants file) required.
+ */
+export interface DatadogLambdaStrictProps {
   readonly addLayers: boolean;
   readonly enableDatadogLogs: boolean;
   readonly captureLambdaPayload: boolean;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. Rename: `DatadogProps` -> `DatadogLambdaProps`
2. Rename: `DefaultDatadogProps` -> `DatadogLambdaDefaultProps`
3. Rename: `DatadogStrictProps` -> `DatadogLambdaStrictProps`
4. Add a type alias `export type DatadogProps = DatadogLambdaProps;` so the renaming won't affect users
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

To make it cleaner to add `DatadogStepFunction` class later. Details in [[RFC] Changing API for Datadog CDK Construct](https://docs.google.com/document/d/1g3bFuhWUayvuS_aS6kOHe_CGECocd8IhoKmM9s4dPU0)

### Testing Guidelines

<!--- How did you test this pull request? --->

`npm test`

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
