### PR TITLE
feat: add skeleton of step function class and example stack

### DIFF
--- a/examples/step-functions-typescript-stack/.npmignore
+++ b/examples/step-functions-typescript-stack/.npmignore
@@ -1,0 +1,6 @@
+*.ts
+!*.d.ts
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/examples/step-functions-typescript-stack/README.md
+++ b/examples/step-functions-typescript-stack/README.md
@@ -1,0 +1,3 @@
+# Datadog CDK TypeScript Example
+
+This example is used to test the [datadog-cdk-constructs](https://github.com/DataDog/datadog-cdk-constructs) v2 library for Step Functions. The Step Functions support is still in development. Once it's ready, this example will be merged into the `typescript-stack` so that a single stack can be used for testing both Lambda functions and Step Functions, making it easier for CDK construct developers to test their changes. The two examples are kept separate for now so the incomplete Step Function support won't break the testing of Lambda functions.

--- a/examples/step-functions-typescript-stack/bin/index.ts
+++ b/examples/step-functions-typescript-stack/bin/index.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import * as cdk from "aws-cdk-lib";
+import { CdkStepFunctionsTypeScriptStack } from "../lib/cdk-step-functions-typescript-stack";
+
+const app = new cdk.App();
+new CdkStepFunctionsTypeScriptStack(app, "CdkStepFunctionsTypeScriptStack", {});
+app.synth();

--- a/examples/step-functions-typescript-stack/cdk.json
+++ b/examples/step-functions-typescript-stack/cdk.json
@@ -1,0 +1,39 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/index.ts",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "yarn.lock",
+      "node_modules"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true
+  }
+}

--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -1,0 +1,40 @@
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
+import { Duration, Stack, StackProps } from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { DatadogStepFunctions } from "datadog-cdk-constructs-v2";
+import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
+
+export class CdkStepFunctionsTypeScriptStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    console.log("Creating Hello World TypeScript stack");
+
+    const helloLambdaFunction = new lambda.Function(this, "hello-python", {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      timeout: Duration.seconds(10),
+      memorySize: 256,
+      code: lambda.Code.fromAsset("../lambda/python", {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_12.bundlingImage,
+          command: ["bash", "-c", "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output"],
+        },
+      }),
+      handler: "hello.lambda_handler",
+    });
+
+    const stateMachine = new sfn.StateMachine(this, "MyStateMachine", {
+      definitionBody: sfn.DefinitionBody.fromChainable(
+        new tasks.LambdaInvoke(this, "MyLambdaTask", {
+          lambdaFunction: helloLambdaFunction,
+        }).next(new sfn.Succeed(this, "GreetedWorld")),
+      ),
+    });
+
+    console.log("Instrumenting Step Functions in TypeScript stack with Datadog");
+
+    const datadogSfn = new DatadogStepFunctions(this, "Datadog", {});
+    datadogSfn.addStateMachines([stateMachine]);
+  }
+}

--- a/examples/step-functions-typescript-stack/package.json
+++ b/examples/step-functions-typescript-stack/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "typescript-stack",
+  "version": "1.0.0",
+  "bin": {
+    "cdk-typescript": "bin/index.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.8.8",
+    "aws-cdk": "^2.134.0",
+    "ts-node": "^10.9.1",
+    "typescript": "~5.2.2"
+  },
+  "dependencies": {
+    "@aws-cdk/aws-lambda-go-alpha": "^2.134.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "^2.134.0-alpha.0",
+    "aws-cdk-lib": "^2.134.0",
+    "constructs": "^10.3.0",
+    "datadog-cdk-constructs-v2": "^1.15.0"
+  }
+}

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed
+ * under the Apache License Version 2.0.
+ *
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
+import { Construct } from "constructs";
+import { DatadogStepFunctionsProps } from "./index";
+
+export class DatadogStepFunctions extends Construct {
+  scope: Construct;
+  props: DatadogStepFunctionsProps;
+  constructor(scope: Construct, id: string, props: DatadogStepFunctionsProps) {
+    super(scope, id);
+    this.scope = scope;
+    this.props = props;
+  }
+
+  public addStateMachines(_stateMachines: sfn.StateMachine[], _construct?: Construct): void {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 
 export * from "./datadog";
 export * from "./datadog-lambda";
+export * from "./datadog-step-functions";
 export * from "./layer";
 export * from "./redirect";
 export * from "./forwarder";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -97,3 +97,5 @@ export interface Node {
 }
 
 export type LambdaFunction = lambda.Function | lambda.SingletonFunction;
+
+export interface DatadogStepFunctionsProps {}


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
<!--- A brief description of the change being made with this pull request. --->
1. Add a skeleton of `DatadogStepFunctions` class, which users will use to add Datadog monitoring for their Step Functions
2. Add an example TypeScript stack showing how to use this class in a CDK
    - a large part of the stack was copied from the existing TypeScript stack for Lambda functions

### Motivation
For [SVLS-4394: Customers can instrument their Step Functions with CDK macro and SAM](https://datadoghq.atlassian.net/browse/SVLS-4394)
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

Followed the [internal wiki for testing local changes to CDK Construct](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723906703/Datadog+CDK+Constructs#Local-Changes)

After `cdk deploy`, a CloudFormation stack was deployed successfully, which includes a Lambda function and a Step Function, though Datadog monitoring is not set up for them.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Please comment on naming. I'm using:
1. `DatadogStepFunctions` as the class name
2. `addStateMachines()` as the function name

Let me know if you prefer to use:
1. the singular form (without `s`), and/or
2. `addStepFunctions()` instead of `addStateMachines()`

Next steps:
1. Implement `DatadogStepFunctions` class, make it do various work needed to set up Datadog monitoring. I'll do this in small steps, sending small PRs.
4. After the TypeScript stack fully works, create an example for Step Functions in Go and Python.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
