### PR TITLE
fix: exclude example stacks from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@ cdk.out/*
 yarn-error.log
 CHANGELOG.md
 CONTRIBUTING.md
+/examples
 /.projen/
 /test-reports/
 junit.xml

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -65,6 +65,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "yarn-error.log",
     "CHANGELOG.md",
     "CONTRIBUTING.md",
+    "/examples",
   ],
   scripts: {
     "check-formatting": "prettier --check src/** integration_tests/**/*.ts examples/**/*.ts",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Exclude the example stacks in `examples/` from the generated Go/Node/Python packages.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

https://github.com/DataDog/datadog-cdk-constructs/issues/283 complains that there CVE security vulnerabilities in the example Go stack, so let's remove the examples and see if it works.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

#### 1. Testing if the example stacks are excluded from the package
Steps:
- Run `npx projen build`
- Go to `dist/go`, `dist/js`, `dist/python` and unpack the generated `.tgz` packages

Result:
- the `examples/` directory is not included in the packages.

#### 2. Testing that this PR fixes security vulnerability
I'm unable to test this because I failed to reproduce the issue. I created docker images using the example Go stack, and used Amazon Inspector to scan it. However, none of the 21 findings (15 critical, 5 medium, 1 untriaged) are from to the CDK construct package. Most are from the `jsii-runtime-go` package. Example:
<img width="820" alt="image" src="https://github.com/user-attachments/assets/86620166-04be-42b3-ab03-92e81a858565">
And excluding `examples/` from the package doesn't change the inspection result. So let's ask the client to test if it works.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Next steps:
- publish a new version
- ask the client to test if the vulnerabilities are gone

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
