### PR TITLE
fix: make DatadogProps available in Python again

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,6 +40,12 @@ export const DatadogLambdaDefaultProps = {
   grantSecretReadAccess: true,
 };
 
+/**
+ * For backward compatibility. It's recommended to use DatadogLambdaDefaultProps for
+ * users who want to add Datadog monitoring for Lambda functions.
+ */
+export const DefaultDatadogProps = DatadogLambdaDefaultProps;
+
 export enum TagKeys {
   CDK = "dd_cdk_construct",
   ENV = "env",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -52,7 +52,7 @@ export interface DatadogLambdaProps {
  * For backward compatibility. It's recommended to use DatadogLambdaProps for
  * users who want to add Datadog monitoring for Lambda functions.
  */
-export type DatadogProps = DatadogLambdaProps;
+export interface DatadogProps extends DatadogLambdaProps {}
 
 /*
  * Makes fields shared with DatadogLambdaDefaultProps (in constants file) required.
@@ -81,6 +81,12 @@ export interface DatadogLambdaStrictProps {
   readonly sourceCodeIntegration?: boolean;
   readonly redirectHandler?: boolean;
 }
+
+/**
+ * For backward compatibility. It's recommended to use DatadogLambdaStrictProps for
+ * users who want to add Datadog monitoring for Lambda functions.
+ */
+export interface DatadogStrictProps extends DatadogLambdaStrictProps {}
 
 export interface Runtime {
   readonly name: string;


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Solves a few backward compatibility issues:
- Change `DatadogProps` from a type to an interface, so there will be a class `DatadogProps` in the generated Python package
- Create an interface `DatadogStrictProps` (which has been renamed to `DatadogLambdaStrictProps` in #288), in case it's still being used by any external code
- Create a const `DefaultDatadogProps` (which has been renamed to `DatadogLambdaDefaultProps` in #288), in case it's still being used by any external code

<!--- A brief description of the change being made with this pull request. --->

### Motivation
Users reported that the class `DatadogProps` is no longer available in the Python package v2-1.16.0. https://github.com/DataDog/datadog-cdk-constructs/issues/294
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
<!--- How did you test this pull request? --->
#### Steps
1. Make changes on the example Python stack to make it use `DatadogProps` https://github.com/DataDog/datadog-cdk-constructs/commit/480eed099a4836360e72365db6edcd1af1d43d36
2. Deploy the stack
#### Result
Before:
- `cdk deploy` gives an error:
> ImportError: cannot import name 'DatadogProps' from 'datadog_cdk_constructs_v2'

After:
- `cdk deploy` runs successfully

### Additional Notes


<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
