### PR TITLE
chore: Refactor example typescript stack by extracting a base class

### DIFF
--- a/examples/typescript-stack/lib/cdk-typescript-stack-base.ts
+++ b/examples/typescript-stack/lib/cdk-typescript-stack-base.ts
@@ -1,0 +1,87 @@
+import { GoFunction } from "@aws-cdk/aws-lambda-go-alpha";
+import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
+import { BundlingOutput, Duration, Stack, StackProps } from "aws-cdk-lib";
+import { Function } from "aws-cdk-lib/aws-lambda";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { Construct } from "constructs";
+
+export class CdkTypeScriptStackBase extends Stack {
+  protected lambdaFunctions: lambda.Function[];
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    console.log("Creating Hello World TypeScript stack");
+
+    const helloNode = new Function(this, "hello-node", {
+      runtime: lambda.Runtime.NODEJS_20_X,
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      code: lambda.Code.fromAsset("../lambda/node", {
+        bundling: {
+          image: lambda.Runtime.NODEJS_20_X.bundlingImage,
+          command: ["bash", "-c", "cp -aT . /asset-output && npm install --prefix /asset-output"],
+          user: "root",
+        },
+      }),
+      handler: "hello.lambda_handler",
+    });
+
+    const helloPython = new Function(this, "hello-python", {
+      runtime: lambda.Runtime.PYTHON_3_12,
+      timeout: Duration.seconds(10),
+      memorySize: 256,
+      code: lambda.Code.fromAsset("../lambda/python", {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_12.bundlingImage,
+          command: ["bash", "-c", "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output"],
+        },
+      }),
+      handler: "hello.lambda_handler",
+    });
+
+    const helloGo = new GoFunction(this, "hello-go", {
+      entry: "../lambda/go/hello.go",
+      architecture: lambda.Architecture.ARM_64,
+      runtime: lambda.Runtime.PROVIDED_AL2,
+      timeout: Duration.seconds(10),
+      bundling: {
+        goBuildFlags: ['-ldflags "-s -w"'],
+      },
+      environment: {
+        LOG_LEVEL: "INFO",
+        TABLE_NAME: "HelloWorld",
+      },
+    });
+
+    const helloDotnet = new Function(this, "hello-dotnet", {
+      runtime: lambda.Runtime.DOTNET_8,
+      handler: "HelloWorld::HelloWorld.Handler::SayHi",
+      memorySize: 256,
+      code: lambda.Code.fromAsset("../lambda/dotnet/", {
+        bundling: {
+          image: lambda.Runtime.DOTNET_8.bundlingImage,
+          command: [
+            "/bin/sh",
+            "-c",
+            " dotnet tool install -g Amazon.Lambda.Tools" +
+              " && dotnet build" +
+              " && dotnet lambda package --output-package /asset-output/function.zip",
+          ],
+          user: "root",
+          outputType: BundlingOutput.ARCHIVED,
+        },
+      }),
+    });
+
+    this.lambdaFunctions = [helloNode, helloPython, helloGo, helloDotnet];
+
+    const dotnetHttpIntegration = new HttpLambdaIntegration("GetDotnetIntegration", helloDotnet);
+    const dotnetHttpApi = new apigwv2.HttpApi(this, "dotnetHttpApi");
+    dotnetHttpApi.addRoutes({
+      path: "/hello",
+      methods: [apigwv2.HttpMethod.GET],
+      integration: dotnetHttpIntegration,
+    });
+  }
+}

--- a/examples/typescript-stack/lib/cdk-typescript-stack.ts
+++ b/examples/typescript-stack/lib/cdk-typescript-stack.ts
@@ -1,90 +1,15 @@
-import { GoFunction } from "@aws-cdk/aws-lambda-go-alpha";
-import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
-import { BundlingOutput, Duration, Stack, StackProps } from "aws-cdk-lib";
-import { Function } from "aws-cdk-lib/aws-lambda";
-import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { DatadogLambda } from "datadog-cdk-constructs-v2";
+import { Datadog, DatadogProps } from "datadog-cdk-constructs-v2";
+import { CdkTypeScriptStackBase } from "./cdk-typescript-stack-base";
 
-export class CdkTypeScriptStack extends Stack {
+export class CdkTypeScriptStack extends CdkTypeScriptStackBase {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    console.log("Creating Hello World TypeScript stack");
-
-    const helloNode = new Function(this, "hello-node", {
-      runtime: lambda.Runtime.NODEJS_20_X,
-      memorySize: 256,
-      timeout: Duration.seconds(10),
-      code: lambda.Code.fromAsset("../lambda/node", {
-        bundling: {
-          image: lambda.Runtime.NODEJS_20_X.bundlingImage,
-          command: ["bash", "-c", "cp -aT . /asset-output && npm install --prefix /asset-output"],
-          user: "root",
-        },
-      }),
-      handler: "hello.lambda_handler",
-    });
-
-    const helloPython = new Function(this, "hello-python", {
-      runtime: lambda.Runtime.PYTHON_3_12,
-      timeout: Duration.seconds(10),
-      memorySize: 256,
-      code: lambda.Code.fromAsset("../lambda/python", {
-        bundling: {
-          image: lambda.Runtime.PYTHON_3_12.bundlingImage,
-          command: ["bash", "-c", "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output"],
-        },
-      }),
-      handler: "hello.lambda_handler",
-    });
-
-    const helloGo = new GoFunction(this, "hello-go", {
-      entry: "../lambda/go/hello.go",
-      architecture: lambda.Architecture.ARM_64,
-      runtime: lambda.Runtime.PROVIDED_AL2,
-      timeout: Duration.seconds(10),
-      bundling: {
-        goBuildFlags: ['-ldflags "-s -w"'],
-      },
-      environment: {
-        LOG_LEVEL: "INFO",
-        TABLE_NAME: "HelloWorld",
-      },
-    });
-
-    const helloDotnet = new Function(this, "hello-dotnet", {
-      runtime: lambda.Runtime.DOTNET_8,
-      handler: "HelloWorld::HelloWorld.Handler::SayHi",
-      memorySize: 256,
-      code: lambda.Code.fromAsset("../lambda/dotnet/", {
-        bundling: {
-          image: lambda.Runtime.DOTNET_8.bundlingImage,
-          command: [
-            "/bin/sh",
-            "-c",
-            " dotnet tool install -g Amazon.Lambda.Tools" +
-              " && dotnet build" +
-              " && dotnet lambda package --output-package /asset-output/function.zip",
-          ],
-          user: "root",
-          outputType: BundlingOutput.ARCHIVED,
-        },
-      }),
-    });
-
-    const dotnetHttpIntegration = new HttpLambdaIntegration("GetDotnetIntegration", helloDotnet);
-    const dotnetHttpApi = new apigwv2.HttpApi(this, "dotnetHttpApi");
-    dotnetHttpApi.addRoutes({
-      path: "/hello",
-      methods: [apigwv2.HttpMethod.GET],
-      integration: dotnetHttpIntegration,
-    });
-
     console.log("Instrumenting Lambda Functions in TypeScript stack with Datadog");
 
-    const datadogLambda = new DatadogLambda(this, "Datadog", {
+    const datadogProps: DatadogProps = {
       dotnetLayerVersion: 15,
       nodeLayerVersion: 108,
       pythonLayerVersion: 89,
@@ -95,8 +20,10 @@ export class CdkTypeScriptStack extends Stack {
       enableDatadogASM: true,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
-    });
+    };
 
-    datadogLambda.addLambdaFunctions([helloNode, helloPython, helloGo, helloDotnet]);
+    const datadog = new Datadog(this, "Datadog", datadogProps);
+
+    datadog.addLambdaFunctions(this.lambdaFunctions);
   }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Right now
```
class CdkTypeScriptStack extends Stack
```
This PR adds a class `CdkTypeScriptStackBase`, and makes:
```
class CdkTypeScriptStackBase extends Stack
```
and
```
class CdkTypeScriptStack extends CdkTypeScriptStackBase
```

`CdkTypeScriptStackBase` contains the setup of AWS resources, not related to Datadog.
`CdkTypeScriptStack` contains Datadog instrumentation code.

### Motivation
I'm going to rename the interfaces like I did in https://github.com/DataDog/datadog-cdk-constructs/pull/288. To make sure both the new API and old API work, I will need to to write two stacks for testing the two APIs. The two stacks will share the non-Datadog setup code, so I'm putting this part in the base class.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
`cdk deploy` successfully deploys the TypeScript stack.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
