### PR TITLE
chore: Refactor example Python stack by extracting a base class

### DIFF
--- a/examples/python-stack/cdk_python/cdk_python_stack.py
+++ b/examples/python-stack/cdk_python/cdk_python_stack.py
@@ -1,99 +1,11 @@
-from aws_cdk import (
-    aws_lambda as _lambda,
-    aws_lambda_go_alpha as go,
-    aws_apigatewayv2 as apigwv2,
-    BundlingOptions,
-    BundlingOutput,
-    Duration,
-    Stack,
-)
 from constructs import Construct
-from datadog_cdk_constructs_v2 import Datadog
+from datadog_cdk_constructs_v2 import Datadog, DatadogProps
 import os
+from cdk_python.cdk_python_stack_base import CdkPythonStackBase
 
-
-class CdkPythonStack(Stack):
+class CdkPythonStack(CdkPythonStackBase):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
-
-        print("Creating Hello World Python stack")
-
-        hello_node = _lambda.Function(
-            self,
-            "hello-node",
-            runtime=_lambda.Runtime.NODEJS_20_X,
-            timeout=Duration.seconds(10),
-            memory_size=256,
-            code=_lambda.Code.from_asset(
-                "../lambda/node",
-                bundling=BundlingOptions(
-                    image=_lambda.Runtime.NODEJS_20_X.bundling_image,
-                    command=[
-                        "bash",
-                        "-c",
-                        "cp -aT . /asset-output && npm install --prefix /asset-output",
-                    ],
-                    user="root",
-                ),
-            ),
-            handler="hello.lambda_handler",
-        )
-
-        hello_python = _lambda.Function(
-            self,
-            "hello-python",
-            runtime=_lambda.Runtime.PYTHON_3_11,
-            timeout=Duration.seconds(10),
-            memory_size=256,
-            code=_lambda.Code.from_asset(
-                "../lambda/python",
-                bundling=BundlingOptions(
-                    image=_lambda.Runtime.PYTHON_3_11.bundling_image,
-                    command=[
-                        "bash",
-                        "-c",
-                        "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output",
-                    ],
-                ),
-            ),
-            handler="hello.lambda_handler",
-        )
-
-        hello_go = go.GoFunction(
-            self,
-            "hello-go",
-            entry="../lambda/go/hello.go",
-            runtime=_lambda.Runtime.PROVIDED_AL2,
-            timeout=Duration.seconds(10),
-            bundling=go.BundlingOptions(
-                go_build_flags=['-ldflags "-s -w"'],
-            ),
-        )
-
-        hello_dotnet = _lambda.Function(
-            self,
-            "hello-dotnet",
-            runtime=_lambda.Runtime.DOTNET_8,
-            handler="HelloWorld::HelloWorld.Handler::SayHi",
-            timeout=Duration.seconds(10),
-            memory_size=256,
-            code=_lambda.Code.from_asset(
-                "../lambda/dotnet",
-                bundling=BundlingOptions(
-                    image=_lambda.Runtime.DOTNET_8.bundling_image,
-                    command=[
-                        '/bin/sh',
-                        '-c',
-                        ' dotnet tool install -g Amazon.Lambda.Tools' +
-                        ' && dotnet build' +
-                        ' && dotnet lambda package --output-package /asset-output/function.zip'
-                    ],
-                    user="root",
-                    output_type=BundlingOutput.ARCHIVED
-                ),
-            ),
-
-        )
 
         datadog = Datadog(
             self,
@@ -109,4 +21,7 @@ class CdkPythonStack(Stack):
             flush_metrics_to_logs=True,
             site="datadoghq.com",
         )
-        datadog.add_lambda_functions([hello_node, hello_python, hello_go, hello_dotnet])
+        
+        # Ensure DatadogProps can be imported properly
+        props = DatadogProps()
+        datadog.add_lambda_functions(self.lambdaFunctions)

--- a/examples/python-stack/cdk_python/cdk_python_stack_base.py
+++ b/examples/python-stack/cdk_python/cdk_python_stack_base.py
@@ -1,0 +1,94 @@
+from aws_cdk import (
+    aws_lambda as _lambda,
+    aws_lambda_go_alpha as go,
+    BundlingOptions,
+    BundlingOutput,
+    Duration,
+    Stack,
+)
+from constructs import Construct
+
+
+class CdkPythonStackBase(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        print("Creating Hello World Python stack")
+
+        hello_node = _lambda.Function(
+            self,
+            "hello-node",
+            runtime=_lambda.Runtime.NODEJS_20_X,
+            timeout=Duration.seconds(10),
+            memory_size=256,
+            code=_lambda.Code.from_asset(
+                "../lambda/node",
+                bundling=BundlingOptions(
+                    image=_lambda.Runtime.NODEJS_20_X.bundling_image,
+                    command=[
+                        "bash",
+                        "-c",
+                        "cp -aT . /asset-output && npm install --prefix /asset-output",
+                    ],
+                    user="root",
+                ),
+            ),
+            handler="hello.lambda_handler",
+        )
+
+        hello_python = _lambda.Function(
+            self,
+            "hello-python",
+            runtime=_lambda.Runtime.PYTHON_3_11,
+            timeout=Duration.seconds(10),
+            memory_size=256,
+            code=_lambda.Code.from_asset(
+                "../lambda/python",
+                bundling=BundlingOptions(
+                    image=_lambda.Runtime.PYTHON_3_11.bundling_image,
+                    command=[
+                        "bash",
+                        "-c",
+                        "pip install -r requirements.txt -t /asset-output && cp -aT . /asset-output",
+                    ],
+                ),
+            ),
+            handler="hello.lambda_handler",
+        )
+
+        hello_go = go.GoFunction(
+            self,
+            "hello-go",
+            entry="../lambda/go/hello.go",
+            runtime=_lambda.Runtime.PROVIDED_AL2,
+            timeout=Duration.seconds(10),
+            bundling=go.BundlingOptions(
+                go_build_flags=['-ldflags "-s -w"'],
+            ),
+        )
+
+        hello_dotnet = _lambda.Function(
+            self,
+            "hello-dotnet",
+            runtime=_lambda.Runtime.DOTNET_8,
+            handler="HelloWorld::HelloWorld.Handler::SayHi",
+            timeout=Duration.seconds(10),
+            memory_size=256,
+            code=_lambda.Code.from_asset(
+                "../lambda/dotnet",
+                bundling=BundlingOptions(
+                    image=_lambda.Runtime.DOTNET_8.bundling_image,
+                    command=[
+                        '/bin/sh',
+                        '-c',
+                        ' dotnet tool install -g Amazon.Lambda.Tools' +
+                        ' && dotnet build' +
+                        ' && dotnet lambda package --output-package /asset-output/function.zip'
+                    ],
+                    user="root",
+                    output_type=BundlingOutput.ARCHIVED
+                ),
+            ),
+        )
+
+        self.lambdaFunctions = [hello_node, hello_python, hello_go, hello_dotnet]


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Right now we have
```
class CdkPythonStack(Stack):
```
This PR adds a class `CdkPythonStackBase`, and makes:
```
class CdkPythonStackBase(Stack):
```
and
```
class CdkPythonStack(CdkPythonStackBase):
```

`CdkPythonStackBase` contains the setup of AWS resources, not related to Datadog.
`CdkPythonStack` contains Datadog instrumentation code.

### Motivation
I'm going to rename the interfaces like I did in https://github.com/DataDog/datadog-cdk-constructs/pull/288. To make sure both the new API and old API work, I will need to to write two stacks for testing the two APIs. The two stacks will share the non-Datadog setup code, so I'm putting this part in the base class.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
`cdk deploy` successfully deploys the Python stack.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
