### PR TITLE
chore: Refactor run_integration_tests.sh by adding stack language check

### DIFF
--- a/integration_tests/stacks/typescript/lambda-function-stack-legacy-datadog-api.ts
+++ b/integration_tests/stacks/typescript/lambda-function-stack-legacy-datadog-api.ts
@@ -11,7 +11,7 @@ import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 // use the legacy Datadog class instead of the new DatadogLambda
-import { Datadog } from "../../src/index";
+import { Datadog } from "../../../src/index";
 
 export class ExampleStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {

--- a/integration_tests/stacks/typescript/lambda-function-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-function-stack.ts
@@ -10,7 +10,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { DatadogLambda } from "../../src/index";
+import { DatadogLambda } from "../../../src/index";
 
 export class ExampleStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {

--- a/integration_tests/stacks/typescript/lambda-provided-arm-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-provided-arm-stack.ts
@@ -3,7 +3,7 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Stack, StackProps, App } from "aws-cdk-lib";
-import { DatadogLambda } from "../../src/index";
+import { DatadogLambda } from "../../../src/index";
 
 export class ExampleStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
@@ -18,6 +18,7 @@ export class ExampleStack extends Stack {
       runtime: lambda.Runtime.PROVIDED_AL2,
       code: lambda.Code.fromBucket(s3Bucket, "fake-key-for-test"),
       handler: "handler.handler",
+      architecture: lambda.Architecture.ARM_64,
     });
 
     s3Bucket.grantRead(providedLambda);
@@ -43,6 +44,6 @@ export class ExampleStack extends Stack {
 
 const app = new App();
 const env = { account: "601427279990", region: "sa-east-1" };
-const stack = new ExampleStack(app, "lambda-provided-stack", { env: env });
+const stack = new ExampleStack(app, "lambda-provided-arm-stack", { env: env });
 console.log("Stack name: " + stack.stackName);
 app.synth();

--- a/integration_tests/stacks/typescript/lambda-provided-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-provided-stack.ts
@@ -3,7 +3,7 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
 import { Stack, StackProps, App } from "aws-cdk-lib";
-import { DatadogLambda } from "../../src/index";
+import { DatadogLambda } from "../../../src/index";
 
 export class ExampleStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
@@ -18,7 +18,6 @@ export class ExampleStack extends Stack {
       runtime: lambda.Runtime.PROVIDED_AL2,
       code: lambda.Code.fromBucket(s3Bucket, "fake-key-for-test"),
       handler: "handler.handler",
-      architecture: lambda.Architecture.ARM_64,
     });
 
     s3Bucket.grantRead(providedLambda);
@@ -44,6 +43,6 @@ export class ExampleStack extends Stack {
 
 const app = new App();
 const env = { account: "601427279990", region: "sa-east-1" };
-const stack = new ExampleStack(app, "lambda-provided-arm-stack", { env: env });
+const stack = new ExampleStack(app, "lambda-provided-stack", { env: env });
 console.log("Stack name: " + stack.stackName);
 app.synth();

--- a/integration_tests/stacks/typescript/lambda-singleton-function-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-singleton-function-stack.ts
@@ -10,7 +10,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import { Stack, StackProps, App } from "aws-cdk-lib";
 import { LambdaRestApi, LogGroupLogDestination } from "aws-cdk-lib/aws-apigateway";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { DatadogLambda } from "../../src/index";
+import { DatadogLambda } from "../../../src/index";
 
 export class ExampleStack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Background
- `integration_tests/stacks/` contains a few example Typescript stacks
- `integration_tests/snapshots/` contains the expected snapshots generated from the stacks
- `scripts/run_integration_tests.sh` generates snapshots from the stacks, and compare the generated stacks with expected stacks

### Motivation
The test only covers TypeScript stacks. We want to cover Python and Go stacks as well to prevent issues like https://github.com/DataDog/datadog-cdk-constructs/issues/294, where the Python package was broken.

### What does this PR do?
1. Move the Typescript stacks to a `typescript/` directory
2. Make `run_integration_tests.sh` check the language of each stack, instead of assuming all stacks are in Typescript. Make the script require that path of a typescript stack should be like `typescript/<name>.ts`.

<!--- A brief description of the change being made with this pull request. --->

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Run `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh`. It finished successfully and the output was same as before.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
