### PR TITLE
chore: Fix a stack in snapshot tests

### DIFF
--- a/integration_tests/snapshots/correct-lambda-function-stack-legacy-datadog-api-snapshot.json
+++ b/integration_tests/snapshots/correct-lambda-function-stack-legacy-datadog-api-snapshot.json
@@ -1,0 +1,505 @@
+{
+ "Resources": {
+  "HelloHandlerServiceRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "lambda.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+       ]
+      ]
+     }
+    ]
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/HelloHandler/ServiceRole/Resource"
+   }
+  },
+  "HelloHandlerXXXXXXXX": {
+   "Type": "AWS::Lambda::Function",
+   "Properties": {
+    "Code": {
+     "ZipFile": "test"
+    },
+    "Environment": {
+     "Variables": {
+      "DD_LAMBDA_HANDLER": "lambdaFunction.handler",
+      "DD_TRACE_ENABLED": "true",
+      "DD_SERVERLESS_APPSEC_ENABLED": "false",
+      "DD_MERGE_XRAY_TRACES": "false",
+      "DD_LOGS_INJECTION": "false",
+      "DD_SERVERLESS_LOGS_ENABLED": "true",
+      "DD_CAPTURE_LAMBDA_PAYLOAD": "false",
+      "DD_FLUSH_TO_LOG": "false",
+      "DD_SITE": "datadoghq.com",
+      "DD_API_KEY": "1234"
+     }
+    },
+    "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
+    "Layers": [
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
+    ],
+    "Role": {
+     "Fn::GetAtt": [
+      "HelloHandlerServiceRoleXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Runtime": "nodejs14.x",
+    "Tags": [
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     }
+    ]
+   },
+   "DependsOn": [
+    "HelloHandlerServiceRoleXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/HelloHandler/Resource"
+   }
+  },
+  "restLogGroupXXXXXXXX": {
+   "Type": "AWS::Logs::LogGroup",
+   "Properties": {
+    "RetentionInDays": 731
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/restLogGroup/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::ApiGateway::RestApi",
+   "Properties": {
+    "Name": "rest-test"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Resource"
+   }
+  },
+  "resttestCloudWatchRoleXXXXXXXX": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "apigateway.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+       ]
+      ]
+     }
+    ]
+   },
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/CloudWatchRole/Resource"
+   }
+  },
+  "resttestAccountXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Account",
+   "Properties": {
+    "CloudWatchRoleArn": {
+     "Fn::GetAtt": [
+      "resttestCloudWatchRoleXXXXXXXX",
+      "Arn"
+     ]
+    }
+   },
+   "DependsOn": [
+    "resttestXXXXXXXX"
+   ],
+   "UpdateReplacePolicy": "Retain",
+   "DeletionPolicy": "Retain",
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Account"
+   }
+  },
+  "resttestDeploymentXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Deployment",
+   "Properties": {
+    "Description": "Automatically created by the RestApi construct",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "DependsOn": [
+    "resttestproxyANYXXXXXXXX",
+    "resttestproxyXXXXXXXX",
+    "resttestANYXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Deployment/Resource"
+   }
+  },
+  "resttestDeploymentStageprodXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Stage",
+   "Properties": {
+    "AccessLogSetting": {
+     "DestinationArn": {
+      "Fn::GetAtt": [
+       "restLogGroupXXXXXXXX",
+       "Arn"
+      ]
+     },
+     "Format": "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] \"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId"
+    },
+    "DeploymentId": {
+     "Ref": "resttestDeploymentXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    },
+    "StageName": "prod"
+   },
+   "DependsOn": [
+    "resttestAccountXXXXXXXX"
+   ],
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/DeploymentStage.prod/Resource"
+   }
+  },
+  "resttestproxyXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Resource",
+   "Properties": {
+    "ParentId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "PathPart": "{proxy+}",
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/{proxy+}/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/{proxy+}/ANY/ApiPermission.lambdafunctionstacklegacydatadogapiresttestF9A49E7D.ANY..{proxy+}"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/*"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/{proxy+}/ANY/ApiPermission.Test.lambdafunctionstacklegacydatadogapiresttestF9A49E7D.ANY..{proxy+}"
+   }
+  },
+  "resttestproxyANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Ref": "resttestproxyXXXXXXXX"
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/{proxy+}/ANY/Resource"
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/",
+       {
+        "Ref": "resttestDeploymentStageprodXXXXXXXX"
+       },
+       "/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/ANY/ApiPermission.lambdafunctionstacklegacydatadogapiresttestF9A49E7D.ANY.."
+   }
+  },
+  "resttestXXXXXXXX": {
+   "Type": "AWS::Lambda::Permission",
+   "Properties": {
+    "Action": "lambda:InvokeFunction",
+    "FunctionName": {
+     "Fn::GetAtt": [
+      "HelloHandlerXXXXXXXX",
+      "Arn"
+     ]
+    },
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": {
+     "Fn::Join": [
+      "",
+      [
+       "arn:",
+       {
+        "Ref": "AWS::Partition"
+       },
+       ":execute-api:sa-east-1:601427279990:",
+       {
+        "Ref": "resttestXXXXXXXX"
+       },
+       "/test-invoke-stage/*/"
+      ]
+     ]
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/ANY/ApiPermission.Test.lambdafunctionstacklegacydatadogapiresttestF9A49E7D.ANY.."
+   }
+  },
+  "resttestANYXXXXXXXX": {
+   "Type": "AWS::ApiGateway::Method",
+   "Properties": {
+    "AuthorizationType": "NONE",
+    "HttpMethod": "ANY",
+    "Integration": {
+     "IntegrationHttpMethod": "POST",
+     "Type": "AWS_PROXY",
+     "Uri": {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":apigateway:sa-east-1:lambda:path/2015-03-31/functions/",
+        {
+         "Fn::GetAtt": [
+          "HelloHandlerXXXXXXXX",
+          "Arn"
+         ]
+        },
+        "/invocations"
+       ]
+      ]
+     }
+    },
+    "ResourceId": {
+     "Fn::GetAtt": [
+      "resttestXXXXXXXX",
+      "RootResourceId"
+     ]
+    },
+    "RestApiId": {
+     "Ref": "resttestXXXXXXXX"
+    }
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/rest-test/Default/ANY/Resource"
+   }
+  },
+  "CDKMetadata": {
+   "Type": "AWS::CDK::Metadata",
+   "Properties": {
+    "Analytics": "vX:XXXXXX:XXXXXX"
+   },
+   "Metadata": {
+    "aws:cdk:path": "lambda-function-stack-legacy-datadog-api/CDKMetadata/Default"
+   }
+  }
+ },
+ "Outputs": {
+  "resttestEndpointXXXXXXXX": {
+   "Value": {
+    "Fn::Join": [
+     "",
+     [
+      "https://",
+      {
+       "Ref": "resttestXXXXXXXX"
+      },
+      ".execute-api.sa-east-1.",
+      {
+       "Ref": "AWS::URLSuffix"
+      },
+      "/",
+      {
+       "Ref": "resttestDeploymentStageprodXXXXXXXX"
+      },
+      "/"
+     ]
+    ]
+   }
+  }
+ },
+ "Parameters": {
+  "BootstrapVersion": {
+   "Type": "AWS::SSM::Parameter::Value<String>",
+   "Default": "/cdk-bootstrap/hnb659fds/version",
+   "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"
+  }
+ },
+ "Rules": {
+  "CheckBootstrapVersion": {
+   "Assertions": [
+    {
+     "Assert": {
+      "Fn::Not": [
+       {
+        "Fn::Contains": [
+         [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+         ],
+         {
+          "Ref": "BootstrapVersion"
+         }
+        ]
+       }
+      ]
+     },
+     "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI."
+    }
+   ]
+  }
+ }
+}

--- a/integration_tests/stacks/typescript/lambda-function-stack-legacy-datadog-api.ts
+++ b/integration_tests/stacks/typescript/lambda-function-stack-legacy-datadog-api.ts
@@ -47,6 +47,6 @@ export class ExampleStack extends Stack {
 
 const app = new App();
 const env = { account: "601427279990", region: "sa-east-1" };
-const stack = new ExampleStack(app, "lambda-function-stack", { env: env });
+const stack = new ExampleStack(app, "lambda-function-stack-legacy-datadog-api", { env: env });
 console.log("Stack name: " + stack.stackName);
 app.synth();


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
`correct-lambda-function-stack-legacy-datadog-api-snapshot.json` is empty. This is because the stack should be called `lambda-function-stack-legacy-datadog-api`, but it is `lambda-function-stack` from copy-paste.

### What does this PR do?
Updates the stack name, so a snapshot can be created with the correct name.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
The snapshot becomes not empty.
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
