### PR TITLE
chore: Remove duplicate work in snapshot tests

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -78,6 +78,9 @@ printOutputAndExit() {
     fi
 }
 
+echo "Setting up for TypeScript stacks"
+npx tsc --project tsconfig.json
+
 echo "Setting up for Python"
 VERSION=$(jq -r '.version' ../version.json)
 cp "$ROOT_DIR/dist/python/datadog-cdk-constructs-v2-$VERSION.tar.gz" stacks/python
@@ -88,7 +91,6 @@ pip install datadog-cdk-constructs-v2-$VERSION.tar.gz
 cd ../..
 
 for ((i = 0; i < ${#STACK_CONFIG_PATHS[@]}; i++)); do
-    npx tsc --project tsconfig.json
     if [[ ${STACK_CONFIG_PATHS[i]} =~ ^typescript/ && ${STACK_CONFIG_PATHS[i]} =~ \.ts$ ]]; then
         # Case 1. TypeScript
         # Strip the ".ts" suffix


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation
The command `npx tsc --project tsconfig.json` compiles the TypeScript test stacks into JavaScript code. Right now it's run once for every stack, which is unnecessary.

### What does this PR do?
Only run this command once at the beginning.
<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Step
1. Run and time the snapshot tests: `time aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh`

#### Result
Before:
> 60.37s user 6.44s system 116% cpu 57.561 total

After:
> 16.10s user 3.61s system 62% cpu 31.789 total

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
