### PR TITLE
feat: [Step Function] Set up logging

### DIFF
--- a/examples/step-functions-typescript-stack/bin/index.ts
+++ b/examples/step-functions-typescript-stack/bin/index.ts
@@ -3,5 +3,7 @@ import * as cdk from "aws-cdk-lib";
 import { CdkStepFunctionsTypeScriptStack } from "../lib/cdk-step-functions-typescript-stack";
 
 const app = new cdk.App();
-new CdkStepFunctionsTypeScriptStack(app, "CdkStepFunctionsTypeScriptStack", {});
+// Ensure there's no identifier collision when a stack has multiple instances in the app
+new CdkStepFunctionsTypeScriptStack(app, "CdkStepFunctionsTypeScriptStack1", {});
+new CdkStepFunctionsTypeScriptStack(app, "CdkStepFunctionsTypeScriptStack2", {});
 app.synth();

--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -24,7 +24,7 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
       handler: "hello.lambda_handler",
     });
 
-    const stateMachine = new sfn.StateMachine(this, "MyStateMachine", {
+    const stateMachine = new sfn.StateMachine(this, "CdkTypeScriptTestStateMachine", {
       definitionBody: sfn.DefinitionBody.fromChainable(
         new tasks.LambdaInvoke(this, "MyLambdaTask", {
           lambdaFunction: helloLambdaFunction,

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -6,6 +6,9 @@
  * Copyright 2021 Datadog, Inc.
  */
 
+import { Token, Stack } from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as logs from "aws-cdk-lib/aws-logs";
 import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import { Construct } from "constructs";
 import { DatadogStepFunctionsProps } from "./index";
@@ -13,11 +16,104 @@ import { DatadogStepFunctionsProps } from "./index";
 export class DatadogStepFunctions extends Construct {
   scope: Construct;
   props: DatadogStepFunctionsProps;
+  stack: Stack;
+
   constructor(scope: Construct, id: string, props: DatadogStepFunctionsProps) {
     super(scope, id);
     this.scope = scope;
     this.props = props;
+    this.stack = Stack.of(this);
   }
 
-  public addStateMachines(_stateMachines: sfn.StateMachine[], _construct?: Construct): void {}
+  public addStateMachines(stateMachines: sfn.StateMachine[], construct?: Construct): void {
+    for (const stateMachine of stateMachines) {
+      this.addStateMachine(stateMachine, construct);
+    }
+  }
+
+  private addStateMachine(stateMachine: sfn.StateMachine, _construct?: Construct) {
+    this.setUpLogging(stateMachine);
+  }
+
+  /**
+   * Set up logging for the given state machine:
+   * 1. Set log level to ALL
+   * 2. Set includeExecutionData to true
+   * 3. Set destination log group (if not set already)
+   * 4. Add permissions to the state machine role to log to CloudWatch Logs
+   */
+  private setUpLogging(stateMachine: sfn.StateMachine) {
+    const cfnStateMachine = stateMachine.node.defaultChild as sfn.CfnStateMachine;
+
+    if (Token.isUnresolved(cfnStateMachine.loggingConfiguration)) {
+      // loggingConfiguration is IResolvable, i.e. an unresolved token
+      throw new Error(
+        `loggingConfiguration is an an unresolved token. \
+Step Function Instrumentation is not supported. \
+Please open a feature request in https://github.com/DataDog/datadog-cdk-constructs.`,
+      );
+    }
+
+    // Set log level and includeExecutionData
+    cfnStateMachine.loggingConfiguration = {
+      ...cfnStateMachine.loggingConfiguration,
+      level: "ALL",
+      includeExecutionData: true,
+    };
+
+    // Set destination log group if not set
+    if (!cfnStateMachine.loggingConfiguration.destinations) {
+      const logGroupName = buildLogGroupName(stateMachine, this.props.env);
+      const logGroup = new logs.LogGroup(stateMachine, "LogGroup", {
+        retention: logs.RetentionDays.ONE_WEEK,
+        logGroupName: logGroupName,
+      });
+
+      cfnStateMachine.loggingConfiguration = {
+        ...cfnStateMachine.loggingConfiguration,
+        destinations: [
+          {
+            cloudWatchLogsLogGroup: {
+              logGroupArn: logGroup.logGroupArn,
+            },
+          } as sfn.CfnStateMachine.LogDestinationProperty,
+        ],
+      };
+    }
+
+    // Configure state machine role to have permission to log to CloudWatch Logs, following
+    // https://docs.aws.amazon.com/step-functions/latest/dg/cw-logs.html#cloudwatch-iam-policy
+    stateMachine.role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "logs:CreateLogDelivery",
+          "logs:CreateLogStream",
+          "logs:GetLogDelivery",
+          "logs:UpdateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:ListLogDeliveries",
+          "logs:PutLogEvents",
+          "logs:PutResourcePolicy",
+          "logs:DescribeResourcePolicies",
+          "logs:DescribeLogGroups",
+        ],
+        resources: ["*"],
+      }),
+    );
+  }
 }
+
+/**
+ * Builds log group name for a state machine using its CDK path.
+ * The path is like "MyStack/MyStateMachine", which includes the stack name and the relative path of the state machine
+ * in the stack. This guarantees no two state machines share the same log group name because:
+ * 1. stack name is unique in a region in an AWS account
+ * 2. relative path is unique in a stack
+ * @returns log group name like "/aws/vendedlogs/states/MyCdkStack-MyStateMachine-Logs" (without env)
+ *                           or "/aws/vendedlogs/states/MyCdkStack-MyStateMachine-Logs-dev" (with env)
+ */
+export const buildLogGroupName = (stateMachine: sfn.StateMachine, env: string | undefined): string => {
+  // Replace / with - in the state machine path to avoid potential parsing issues in other systems such as forwarder
+  const path = stateMachine.node.path.replace(/\//g, "-");
+  return `/aws/vendedlogs/states/${path}-Logs${env !== undefined ? "-" + env : ""}`;
+};

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -98,4 +98,6 @@ export interface Node {
 
 export type LambdaFunction = lambda.Function | lambda.SingletonFunction;
 
-export interface DatadogStepFunctionsProps {}
+export interface DatadogStepFunctionsProps {
+  readonly env?: string;
+}

--- a/test/datadog-step-functions.spec.ts
+++ b/test/datadog-step-functions.spec.ts
@@ -1,0 +1,82 @@
+import { Stack, Token } from "aws-cdk-lib";
+import * as logs from "aws-cdk-lib/aws-logs";
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
+import { DatadogStepFunctions, buildLogGroupName } from "../src/datadog-step-functions";
+
+describe("DatadogStepFunctions", () => {
+  describe("updateLogConfig", () => {
+    it("sets up log config if it's not set", () => {
+      const stack = new Stack();
+      const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
+        definition: new sfn.Pass(stack, "PassState"),
+      });
+
+      const datadogSfn = new DatadogStepFunctions(stack, "DatadogStepFunctions", {});
+      datadogSfn.addStateMachines([stateMachine]);
+
+      const cfnStateMachine = stateMachine.node.defaultChild as sfn.CfnStateMachine;
+      const logConfig = cfnStateMachine.loggingConfiguration as sfn.CfnStateMachine.LoggingConfigurationProperty;
+      expect(logConfig.level).toBe("ALL");
+      expect(logConfig.includeExecutionData).toBe(true);
+      expect(logConfig.destinations).toHaveLength(1);
+    });
+
+    it("sets log level to ALL and includeExecutionData to true if they are not", () => {
+      const stack = new Stack();
+      const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
+        definition: new sfn.Pass(stack, "PassState"),
+        logs: {
+          destination: new logs.LogGroup(stack, "LogGroup"),
+          level: sfn.LogLevel.ERROR,
+          includeExecutionData: false,
+        },
+      });
+
+      const datadogSfn = new DatadogStepFunctions(stack, "DatadogStepFunctions", {});
+      datadogSfn.addStateMachines([stateMachine]);
+
+      const cfnStateMachine = stateMachine.node.defaultChild as sfn.CfnStateMachine;
+      const logConfig = cfnStateMachine.loggingConfiguration as sfn.CfnStateMachine.LoggingConfigurationProperty;
+      expect(logConfig.level).toBe("ALL");
+      expect(logConfig.includeExecutionData).toBe(true);
+      expect(logConfig.destinations).toHaveLength(1);
+    });
+
+    it("throws if loggingConfiguration is an unresolved token", () => {
+      const stack = new Stack();
+      const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
+        definition: new sfn.Pass(stack, "PassState"),
+      });
+
+      const cfnStateMachine = stateMachine.node.defaultChild as sfn.CfnStateMachine;
+      cfnStateMachine.loggingConfiguration = Token.asAny({});
+
+      const datadogSfn = new DatadogStepFunctions(stack, "DatadogStepFunctions", {});
+      expect(() => datadogSfn.addStateMachines([stateMachine])).toThrowError(
+        "loggingConfiguration is an an unresolved token. Step Function Instrumentation is not supported. Please open a feature request in https://github.com/DataDog/datadog-cdk-constructs.",
+      );
+    });
+  });
+});
+
+describe("buildLogGroupName", () => {
+  test("builds log group name with env", () => {
+    const stateMachine = {
+      node: {
+        path: "MyStack/MyStateMachine",
+      },
+    } as sfn.StateMachine;
+    const logGroupName = buildLogGroupName(stateMachine, "dev");
+    expect(logGroupName).toBe("/aws/vendedlogs/states/MyStack-MyStateMachine-Logs-dev");
+  });
+
+  test("builds log group name without env", () => {
+    const stateMachine = {
+      node: {
+        path: "MyStack/MyStateMachine",
+      },
+    } as sfn.StateMachine;
+    const logGroupName = buildLogGroupName(stateMachine, undefined);
+    expect(logGroupName).toBe("/aws/vendedlogs/states/MyStack-MyStateMachine-Logs");
+  });
+});


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Enables setting up logging for a given state machine:
1. Set log level to ALL
2. Set includeExecutionData to true
3. Set destination log group (if not set already)
4. Add permissions to the state machine role to log to CloudWatch Logs
<!--- A brief description of the change being made with this pull request. --->

### Motivation

This is the first step of instrumenting a step function.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

#### Automated Testing

Passed the added tests.

#### Manual Testing

Successfully deployed the example app `step-functions-typescript-stack`, which contains two stacks.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
