### PR TITLE
feat: [Step Function] Set tags

### DIFF
--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -2,7 +2,7 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import { Duration, Stack, StackProps } from "aws-cdk-lib";
 import { Construct } from "constructs";
-import { DatadogStepFunctions } from "datadog-cdk-constructs-v2";
+import { DatadogStepFunctions, DatadogLambda } from "datadog-cdk-constructs-v2";
 import * as tasks from "aws-cdk-lib/aws-stepfunctions-tasks";
 
 export class CdkStepFunctionsTypeScriptStack extends Stack {
@@ -34,10 +34,25 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
 
     console.log("Instrumenting Step Functions in TypeScript stack with Datadog");
 
-    const datadogSfn = new DatadogStepFunctions(this, "Datadog", {
+    const datadogSfn = new DatadogStepFunctions(this, "DatadogSfn", {
       env: "dev",
+      service: "my-service",
+      version: "1.0.0",
       forwarderArn: process.env.DD_FORWARDER_ARN,
+      tags: "custom-tag-1:tag-value-1,custom-tag-2:tag-value-2",
     });
     datadogSfn.addStateMachines([stateMachine]);
+
+    const datadogLambda = new DatadogLambda(this, "DatadogLambda", {
+      pythonLayerVersion: 89,
+      extensionLayerVersion: 55,
+      addLayers: true,
+      apiKey: process.env.DD_API_KEY,
+      enableDatadogTracing: true,
+      enableDatadogASM: true,
+      flushMetricsToLogs: true,
+      site: "datadoghq.com",
+    });
+    datadogLambda.addLambdaFunctions([helloLambdaFunction]);
   }
 }

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -14,6 +14,7 @@ import { Construct } from "constructs";
 import log from "loglevel";
 import { addForwarderForStateMachine } from "./forwarder";
 import { DatadogStepFunctionsProps } from "./index";
+import { setTags } from "./tag";
 
 const unsupportedCaseErrorMessage =
   "Step Function Instrumentation is not supported. \
@@ -45,6 +46,8 @@ export class DatadogStepFunctions extends Construct {
     } else {
       log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
     }
+
+    setTags(stateMachine, this.props);
   }
 
   /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -100,5 +100,8 @@ export type LambdaFunction = lambda.Function | lambda.SingletonFunction;
 
 export interface DatadogStepFunctionsProps {
   readonly env?: string;
+  readonly service?: string;
+  readonly version?: string;
   readonly forwarderArn?: string;
+  readonly tags?: string;
 }

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -8,10 +8,14 @@
 
 import { Tags } from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import log from "loglevel";
-import { TagKeys, DatadogLambdaProps } from "./index";
+import { TagKeys, DatadogLambdaProps, DatadogStepFunctionsProps } from "./index";
 
-export function setTags(resource: lambda.Function, props: DatadogLambdaProps): void {
+export function setTags(
+  resource: lambda.Function | sfn.StateMachine,
+  props: DatadogLambdaProps | DatadogStepFunctionsProps,
+): void {
   log.debug(`Adding datadog tags`);
   if (props.env) {
     Tags.of(resource).add(TagKeys.ENV, props.env);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Enables setting tags for the state machine, including DD tags and custom tags. For example, if the user passes these properties to Datadog:
```
    const datadogSfn = new DatadogStepFunctions(this, "Datadog", {
      env: "dev",
      service: "my-service",
      version: "1.0.0",
      forwarderArn: process.env.DD_FORWARDER_ARN,
      tags: "custom-tag-1:tag-value-1,custom-tag-2:tag-value-2",
    });
    datadogSfn.addStateMachines([stateMachine]);
```
Then the state machine will have these tags:
- `DD_ENV`: `env`
- `DD_SERVICE`: `my-service`
- `DD_VERSION`: `1.0.0`
- `custom-tag-1`: `tag-value-1`
- `custom-tag-2`: `tag-value-2`

<!--- A brief description of the change being made with this pull request. --->

### Motivation
This is one step of instrumenting a step function.
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Passed the added test

#### Manual testing

Deployed the example stacks `step-functions-typescript-stack`. The tags are set as expected.
<img width="537" alt="image" src="https://github.com/user-attachments/assets/150d3b5a-1e6a-4c13-845c-92e4a61c5516">

<!--- How did you test this pull request? --->

### Additional Notes
Need a stamp from Cloud Tracing team, who, as the downstream consumer, should know what tags should be set here.
<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
