### PR TITLE
chore: Make helpers take one, not multiple Lambda functions (2/x)

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -84,19 +84,19 @@ export class DatadogLambda extends Construct {
         log.debug("Granting read access to the provided Secret ARN for all your lambda functions.");
         grantReadLambdaFromSecretArn(construct, this.props.apiKeySecretArn, lambdaFunction);
       }
-    }
 
-    if (baseProps.addLayers) {
-      applyLayers(
-        this.scope,
-        region,
-        extractedLambdaFunctions,
-        this.props.pythonLayerVersion,
-        this.props.nodeLayerVersion,
-        this.props.javaLayerVersion,
-        this.props.dotnetLayerVersion,
-        this.props.useLayersFromAccount,
-      );
+      if (baseProps.addLayers) {
+        applyLayers(
+          this.scope,
+          region,
+          lambdaFunction,
+          this.props.pythonLayerVersion,
+          this.props.nodeLayerVersion,
+          this.props.javaLayerVersion,
+          this.props.dotnetLayerVersion,
+          this.props.useLayersFromAccount,
+        );
+      }
     }
 
     if (baseProps.extensionLayerVersion !== undefined) {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Context of this PR series

The end goal of this series of PRs is to abort the instrumentation of a Lambda function if its runtime is not supported, while still instrument other Lambda functions. More in https://github.com/DataDog/datadog-cdk-constructs/issues/314

However, this behavior is hard to implement under the current code structure:
```
public addLambdaFunctions() {
  grantReadLambdas(lambdas);
  applyLayers(lambdas);
  applyExtensionLayer(lambdas);
  ...
}
```

If one of the steps skips a Lambda function, it's hard for the subsequent steps to know this and thus skip the Lambda function.

Therefore, at the end of day, I'm going to change the code structure to:
```
public addLambdaFunctions() {
  for (lambda : lambdas) {
    addLambdaFunction(lambda);
  }
}

public addLambdaFunction() {
  if (!grantReadLambda(lambda)) {
    return;
  }

  if (!applyLayers(lambda)) {
    return;
  }
  ...
}
```

to make it possible to implement this behavior.

### What does this PR do?

This PR makes these helper functions to take a single Lambda function instead of multiple ones:
- `applyLayers()`

It's not supposed to change code behavior.

I'll handle other helper functions in separate PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines

Run snapshot tests: `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh` to ensure the generated CloudFormation template for the test stacks are not changed.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
