### PR TITLE
chore: Fix warnings in tests

### DIFF
--- a/test/datadog-step-functions.spec.ts
+++ b/test/datadog-step-functions.spec.ts
@@ -8,7 +8,7 @@ describe("DatadogStepFunctions", () => {
     it("sets up log config if it's not set", () => {
       const stack = new Stack();
       const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
-        definition: new sfn.Pass(stack, "PassState"),
+        definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, "PassState")),
       });
 
       const datadogSfn = new DatadogStepFunctions(stack, "DatadogStepFunctions", {});
@@ -24,7 +24,7 @@ describe("DatadogStepFunctions", () => {
     it("sets log level to ALL and includeExecutionData to true if they are not", () => {
       const stack = new Stack();
       const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
-        definition: new sfn.Pass(stack, "PassState"),
+        definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, "PassState")),
         logs: {
           destination: new logs.LogGroup(stack, "LogGroup"),
           level: sfn.LogLevel.ERROR,
@@ -45,7 +45,7 @@ describe("DatadogStepFunctions", () => {
     it("throws if loggingConfiguration is an unresolved token", () => {
       const stack = new Stack();
       const stateMachine = new sfn.StateMachine(stack, "StateMachine", {
-        definition: new sfn.Pass(stack, "PassState"),
+        definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, "PassState")),
       });
 
       const cfnStateMachine = stateMachine.node.defaultChild as sfn.CfnStateMachine;

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -109,6 +109,7 @@ describe("applyEnvVariables", () => {
       enableDatadogASM: true,
       extensionLayerVersion: 50,
       apiKey: "test",
+      nodeLayerVersion: NODE_LAYER_VERSION,
     });
     datadogLambda.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. Change the way to set up a State Machine in Jest tests so this warning won't be printed when we run `npm test`:
<img width="757" alt="image" src="https://github.com/user-attachments/assets/7f06c035-6dc4-4340-b415-398f497dd953">

2. Pass a required Datadog prop `nodeLayerVersion` so this error-level log won't be printed:
<img width="758" alt="image" src="https://github.com/user-attachments/assets/bd8f8c9f-d218-4228-94dc-d4eca42126ca">

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
Run `npm test`. The output is now clean:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/9b261e19-30a1-4ab1-a3ae-996e03c0d8d1">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
