### PR TITLE
feat: Support SFN->Lambda trace merging

### DIFF
--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -28,6 +28,7 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
       definitionBody: sfn.DefinitionBody.fromChainable(
         new tasks.LambdaInvoke(this, "MyLambdaTask", {
           lambdaFunction: helloLambdaFunction,
+          payload: sfn.TaskInput.fromObject(DatadogStepFunctions.buildLambdaPayloadToMergeTraces()),
         }).next(new sfn.Succeed(this, "GreetedWorld")),
       ),
     });
@@ -36,7 +37,7 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
 
     const datadogSfn = new DatadogStepFunctions(this, "DatadogSfn", {
       env: "dev",
-      service: "my-service",
+      service: "cdk-test-service",
       version: "1.0.0",
       forwarderArn: process.env.DD_FORWARDER_ARN,
       tags: "custom-tag-1:tag-value-1,custom-tag-2:tag-value-2",
@@ -44,14 +45,17 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
     datadogSfn.addStateMachines([stateMachine]);
 
     const datadogLambda = new DatadogLambda(this, "DatadogLambda", {
-      pythonLayerVersion: 89,
-      extensionLayerVersion: 55,
+      pythonLayerVersion: 101,
+      extensionLayerVersion: 65,
       addLayers: true,
       apiKey: process.env.DD_API_KEY,
       enableDatadogTracing: true,
       enableDatadogASM: true,
       flushMetricsToLogs: true,
       site: "datadoghq.com",
+      env: "dev",
+      service: "cdk-test-service",
+      version: "1.0.0",
     });
     datadogLambda.addLambdaFunctions([helloLambdaFunction]);
   }

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -14,6 +14,7 @@ import { Construct } from "constructs";
 import log from "loglevel";
 import { addForwarderForStateMachine } from "./forwarder";
 import { DatadogStepFunctionsProps } from "./index";
+import { buildStepFunctionLambdaTaskPayloadToMergeTraces } from "./span-link";
 import { setTags } from "./tag";
 
 const unsupportedCaseErrorMessage =
@@ -21,6 +22,10 @@ const unsupportedCaseErrorMessage =
 Please open a feature request in https://github.com/DataDog/datadog-cdk-constructs.";
 
 export class DatadogStepFunctions extends Construct {
+  public static buildLambdaPayloadToMergeTraces(payload: { [key: string]: any } = {}): { [key: string]: any } {
+    return buildStepFunctionLambdaTaskPayloadToMergeTraces(payload);
+  }
+
   scope: Construct;
   props: DatadogStepFunctionsProps;
   stack: Stack;

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -1,0 +1,33 @@
+/**
+ * Builds a payload for a Step Function LambdaInvoke task, so the Step Function traces
+ * can be merged with downstream Lambda traces.
+ *
+ * This function modifies the provided payload to include context fields necessary
+ * for trace merging purposes. If the payload already contains any of these fields,
+ * an error is thrown to avoid conflicts.
+ *
+ * @param payload - The user's payload object. Defaults to an empty object.
+ * @returns The modified payload object with necessary context added.
+ * @throws {ConflictError} If the payload already contains `Execution`, `State`, or `StateMachine` fields.
+ */
+export function buildStepFunctionLambdaTaskPayloadToMergeTraces(payload: { [key: string]: any } = {}): {
+  [key: string]: any;
+} {
+  if (
+    "Execution" in payload ||
+    "Execution.$" in payload ||
+    "State" in payload ||
+    "State.$" in payload ||
+    "StateMachine" in payload ||
+    "StateMachine.$" in payload
+  ) {
+    throw new Error(`The LambdaInvoke task may be using custom Execution, State or StateMachine field. \
+Step Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. \
+Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.`);
+  }
+
+  payload["Execution.$"] = "$$.Execution";
+  payload["State.$"] = "$$.State";
+  payload["StateMachine.$"] = "$$.StateMachine";
+  return payload;
+}

--- a/test/span-link.spec.ts
+++ b/test/span-link.spec.ts
@@ -1,0 +1,30 @@
+import { buildStepFunctionLambdaTaskPayloadToMergeTraces } from "../src/span-link";
+
+describe("buildStepFunctionLambdaTaskPayloadToMergeTraces", () => {
+  it("adds necessary fields to an empty payload", () => {
+    const result = buildStepFunctionLambdaTaskPayloadToMergeTraces();
+    expect(result).toEqual({
+      "Execution.$": "$$.Execution",
+      "State.$": "$$.State",
+      "StateMachine.$": "$$.StateMachine",
+    });
+  });
+
+  it("adds necessary fields to a non-empty payload", () => {
+    const payload = { "custom-key": "custom-value" };
+    const result = buildStepFunctionLambdaTaskPayloadToMergeTraces(payload);
+    expect(result).toEqual({
+      "custom-key": "custom-value",
+      "Execution.$": "$$.Execution",
+      "State.$": "$$.State",
+      "StateMachine.$": "$$.StateMachine",
+    });
+  });
+
+  it("throws an error if payload already contains Execution field", () => {
+    const payload = { Execution: "value" };
+    expect(() => buildStepFunctionLambdaTaskPayloadToMergeTraces(payload)).toThrowError(
+      "The LambdaInvoke task may be using custom Execution, State or StateMachine field. Step Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.",
+    );
+  });
+});


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Support merging Step Function traces with downstream LambdaInvoke step traces.

If the user constructs their state machine using:
```diff
    const stateMachine = new sfn.StateMachine(this, "CdkTypeScriptTestStateMachine", {
      definitionBody: sfn.DefinitionBody.fromChainable(
        new tasks.LambdaInvoke(this, "MyLambdaTask", {
          lambdaFunction: helloLambdaFunction,
+         payload: sfn.TaskInput.fromObject(DatadogStepFunctions.buildLambdaPayloadToMergeTraces()),
        }).next(new sfn.Succeed(this, "GreetedWorld")),
      ),
    });
```

Then we will add these fields to their Lambda payload:
```
      "Execution.$": "$$.Execution",
      "State.$": "$$.State",
      "StateMachine.$": "$$.StateMachine",
```

which will enable merging Step Function traces with Lambda traces.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
Passed the added unit tests.

#### Manual testing
##### Steps
1. Deploy the example typescript step function stack
2. Run the State Machine once
##### Result
1. The three fields are added to Lambda payload
<img width="416" alt="image" src="https://github.com/user-attachments/assets/5714d1ce-50ba-4f04-828e-1e160e3de042">

2. The flame graph of the step function also shows the Lambda flame graph

<img width="1059" alt="image" src="https://github.com/user-attachments/assets/ce9ff1b2-d545-46fc-8c9d-da463c002177">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
