### PR TITLE
feat: Support StepFunction->StepFunction trace merging

### DIFF
--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -11,6 +11,25 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
 
     console.log("Creating Hello World TypeScript stack");
 
+    /* Set up the child state machine */
+
+    const passState = new sfn.Pass(this, "PassState");
+    const waitState = new sfn.Wait(this, "WaitState", { time: sfn.WaitTime.duration(Duration.seconds(1)) });
+    const successState = new sfn.Succeed(this, "SuccessState");
+
+    const childStateMachine = new sfn.StateMachine(this, "CdkTypeScriptTestChildStateMachine", {
+      definitionBody: sfn.DefinitionBody.fromChainable(passState.next(waitState).next(successState)),
+    });
+
+    /* Set up the parent state machine */
+
+    const invokeChildStateMachineTask = new tasks.StepFunctionsStartExecution(this, "InvokeChildStateMachineTask", {
+      stateMachine: childStateMachine,
+      input: sfn.TaskInput.fromObject(
+        DatadogStepFunctions.buildStepFunctionTaskPayloadToMergeTraces({ "custom-key": "custom-value" }),
+      ),
+    });
+
     const helloLambdaFunction = new lambda.Function(this, "hello-python", {
       runtime: lambda.Runtime.PYTHON_3_12,
       timeout: Duration.seconds(10),
@@ -24,14 +43,16 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
       handler: "hello.lambda_handler",
     });
 
-    const stateMachine = new sfn.StateMachine(this, "CdkTypeScriptTestStateMachine", {
-      definitionBody: sfn.DefinitionBody.fromChainable(
-        new tasks.LambdaInvoke(this, "MyLambdaTask", {
-          lambdaFunction: helloLambdaFunction,
-          payload: sfn.TaskInput.fromObject(DatadogStepFunctions.buildLambdaPayloadToMergeTraces()),
-        }).next(new sfn.Succeed(this, "GreetedWorld")),
-      ),
+    const lambdaTask = new tasks.LambdaInvoke(this, "MyLambdaTask", {
+      lambdaFunction: helloLambdaFunction,
+      payload: sfn.TaskInput.fromObject(DatadogStepFunctions.buildLambdaPayloadToMergeTraces()),
     });
+
+    const parentStateMachine = new sfn.StateMachine(this, "CdkTypeScriptTestStateMachine", {
+      definitionBody: sfn.DefinitionBody.fromChainable(lambdaTask.next(invokeChildStateMachineTask)),
+    });
+
+    /* Instrument the lambda functions and the state machines */
 
     console.log("Instrumenting Step Functions in TypeScript stack with Datadog");
 
@@ -42,7 +63,7 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
       forwarderArn: process.env.DD_FORWARDER_ARN,
       tags: "custom-tag-1:tag-value-1,custom-tag-2:tag-value-2",
     });
-    datadogSfn.addStateMachines([stateMachine]);
+    datadogSfn.addStateMachines([childStateMachine, parentStateMachine]);
 
     const datadogLambda = new DatadogLambda(this, "DatadogLambda", {
       pythonLayerVersion: 101,

--- a/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
+++ b/examples/step-functions-typescript-stack/lib/cdk-step-functions-typescript-stack.ts
@@ -26,7 +26,7 @@ export class CdkStepFunctionsTypeScriptStack extends Stack {
     const invokeChildStateMachineTask = new tasks.StepFunctionsStartExecution(this, "InvokeChildStateMachineTask", {
       stateMachine: childStateMachine,
       input: sfn.TaskInput.fromObject(
-        DatadogStepFunctions.buildStepFunctionTaskPayloadToMergeTraces({ "custom-key": "custom-value" }),
+        DatadogStepFunctions.buildStepFunctionTaskInputToMergeTraces({ "custom-key": "custom-value" }),
       ),
     });
 

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -16,7 +16,7 @@ import { addForwarderForStateMachine } from "./forwarder";
 import { DatadogStepFunctionsProps } from "./index";
 import {
   buildStepFunctionLambdaTaskPayloadToMergeTraces,
-  buildStepFunctionSfnExecutionTaskPayloadToMergeTraces,
+  buildStepFunctionSfnExecutionTaskInputToMergeTraces,
 } from "./span-link";
 import { setTags } from "./tag";
 
@@ -29,10 +29,10 @@ export class DatadogStepFunctions extends Construct {
     return buildStepFunctionLambdaTaskPayloadToMergeTraces(payload);
   }
 
-  public static buildStepFunctionTaskPayloadToMergeTraces(payload: { [key: string]: any } = {}): {
+  public static buildStepFunctionTaskInputToMergeTraces(input: { [key: string]: any } = {}): {
     [key: string]: any;
   } {
-    return buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload);
+    return buildStepFunctionSfnExecutionTaskInputToMergeTraces(input);
   }
 
   scope: Construct;

--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -14,7 +14,10 @@ import { Construct } from "constructs";
 import log from "loglevel";
 import { addForwarderForStateMachine } from "./forwarder";
 import { DatadogStepFunctionsProps } from "./index";
-import { buildStepFunctionLambdaTaskPayloadToMergeTraces } from "./span-link";
+import {
+  buildStepFunctionLambdaTaskPayloadToMergeTraces,
+  buildStepFunctionSfnExecutionTaskPayloadToMergeTraces,
+} from "./span-link";
 import { setTags } from "./tag";
 
 const unsupportedCaseErrorMessage =
@@ -24,6 +27,12 @@ Please open a feature request in https://github.com/DataDog/datadog-cdk-construc
 export class DatadogStepFunctions extends Construct {
   public static buildLambdaPayloadToMergeTraces(payload: { [key: string]: any } = {}): { [key: string]: any } {
     return buildStepFunctionLambdaTaskPayloadToMergeTraces(payload);
+  }
+
+  public static buildStepFunctionTaskPayloadToMergeTraces(payload: { [key: string]: any } = {}): {
+    [key: string]: any;
+  } {
+    return buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload);
   }
 
   scope: Construct;

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -31,3 +31,29 @@ Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to dis
   payload["StateMachine.$"] = "$$.StateMachine";
   return payload;
 }
+
+/**
+ * Builds a payload for a Step Function execution task, so the Step Function traces
+ * can be merged with downstream Step Function traces.
+ *
+ * This function modifies the provided payload to include context fields necessary
+ * for trace merging purposes. If the payload already contains CONTEXT or CONTEXT.$ field,
+ * an error is thrown to avoid conflicts.
+ *
+ * @param payload - The user's payload object. Defaults to an empty object.
+ * @returns The modified payload object with necessary context added.
+ * @throws {ConflictError} If the payload already contains `CONTEXT` or `CONTEXT.$` fields.
+ */
+
+export function buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload: { [key: string]: any } = {}): {
+  [key: string]: any;
+} {
+  if ("CONTEXT" in payload || "CONTEXT.$" in payload) {
+    throw new Error(`The StepFunction StartExecution task may be using custom CONTEXT field. Step Functions Context Object injection skipped. \
+Your Step Functions trace will not be merged with downstream Lambda traces. \
+Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.`);
+  }
+
+  payload["CONTEXT.$"] = `$$['Execution', 'State', 'StateMachine']`;
+  return payload;
+}

--- a/src/span-link.ts
+++ b/src/span-link.ts
@@ -33,27 +33,27 @@ Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to dis
 }
 
 /**
- * Builds a payload for a Step Function execution task, so the Step Function traces
+ * Builds an input for a Step Function execution task, so the Step Function traces
  * can be merged with downstream Step Function traces.
  *
- * This function modifies the provided payload to include context fields necessary
- * for trace merging purposes. If the payload already contains CONTEXT or CONTEXT.$ field,
+ * This function modifies the provided input to include context fields necessary
+ * for trace merging purposes. If the input already contains CONTEXT or CONTEXT.$ field,
  * an error is thrown to avoid conflicts.
  *
- * @param payload - The user's payload object. Defaults to an empty object.
- * @returns The modified payload object with necessary context added.
- * @throws {ConflictError} If the payload already contains `CONTEXT` or `CONTEXT.$` fields.
+ * @param input - The user's input object. Defaults to an empty object.
+ * @returns The modified input object with necessary context added.
+ * @throws {ConflictError} If the input already contains `CONTEXT` or `CONTEXT.$` fields.
  */
 
-export function buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload: { [key: string]: any } = {}): {
+export function buildStepFunctionSfnExecutionTaskInputToMergeTraces(input: { [key: string]: any } = {}): {
   [key: string]: any;
 } {
-  if ("CONTEXT" in payload || "CONTEXT.$" in payload) {
+  if ("CONTEXT" in input || "CONTEXT.$" in input) {
     throw new Error(`The StepFunction StartExecution task may be using custom CONTEXT field. Step Functions Context Object injection skipped. \
 Your Step Functions trace will not be merged with downstream Lambda traces. \
 Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.`);
   }
 
-  payload["CONTEXT.$"] = `$$['Execution', 'State', 'StateMachine']`;
-  return payload;
+  input["CONTEXT.$"] = `$$['Execution', 'State', 'StateMachine']`;
+  return input;
 }

--- a/test/span-link.spec.ts
+++ b/test/span-link.spec.ts
@@ -1,6 +1,6 @@
 import {
   buildStepFunctionLambdaTaskPayloadToMergeTraces,
-  buildStepFunctionSfnExecutionTaskPayloadToMergeTraces,
+  buildStepFunctionSfnExecutionTaskInputToMergeTraces,
 } from "../src/span-link";
 
 describe("buildStepFunctionLambdaTaskPayloadToMergeTraces", () => {
@@ -32,26 +32,26 @@ describe("buildStepFunctionLambdaTaskPayloadToMergeTraces", () => {
   });
 });
 
-describe("buildStepFunctionExecutionStepPayloadToMergeTraces", () => {
-  it("adds necessary fields to an empty payload", () => {
-    const result = buildStepFunctionSfnExecutionTaskPayloadToMergeTraces();
+describe("buildStepFunctionSfnExecutionTaskInputToMergeTraces", () => {
+  it("adds necessary fields to an empty input", () => {
+    const result = buildStepFunctionSfnExecutionTaskInputToMergeTraces();
     expect(result).toEqual({
       "CONTEXT.$": `$$['Execution', 'State', 'StateMachine']`,
     });
   });
 
-  it("adds necessary fields to a non-empty payload", () => {
-    const payload = { "custom-key": "custom-value" };
-    const result = buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload);
+  it("adds necessary fields to a non-empty input", () => {
+    const input = { "custom-key": "custom-value" };
+    const result = buildStepFunctionSfnExecutionTaskInputToMergeTraces(input);
     expect(result).toEqual({
       "custom-key": "custom-value",
       "CONTEXT.$": `$$['Execution', 'State', 'StateMachine']`,
     });
   });
 
-  it("throws an error if payload already contains CONTEXT field", () => {
-    const payload = { CONTEXT: "value" };
-    expect(() => buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload)).toThrowError(
+  it("throws an error if input already contains CONTEXT field", () => {
+    const input = { CONTEXT: "value" };
+    expect(() => buildStepFunctionSfnExecutionTaskInputToMergeTraces(input)).toThrowError(
       "The StepFunction StartExecution task may be using custom CONTEXT field. Step Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.",
     );
   });

--- a/test/span-link.spec.ts
+++ b/test/span-link.spec.ts
@@ -1,4 +1,7 @@
-import { buildStepFunctionLambdaTaskPayloadToMergeTraces } from "../src/span-link";
+import {
+  buildStepFunctionLambdaTaskPayloadToMergeTraces,
+  buildStepFunctionSfnExecutionTaskPayloadToMergeTraces,
+} from "../src/span-link";
 
 describe("buildStepFunctionLambdaTaskPayloadToMergeTraces", () => {
   it("adds necessary fields to an empty payload", () => {
@@ -25,6 +28,31 @@ describe("buildStepFunctionLambdaTaskPayloadToMergeTraces", () => {
     const payload = { Execution: "value" };
     expect(() => buildStepFunctionLambdaTaskPayloadToMergeTraces(payload)).toThrowError(
       "The LambdaInvoke task may be using custom Execution, State or StateMachine field. Step Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.",
+    );
+  });
+});
+
+describe("buildStepFunctionExecutionStepPayloadToMergeTraces", () => {
+  it("adds necessary fields to an empty payload", () => {
+    const result = buildStepFunctionSfnExecutionTaskPayloadToMergeTraces();
+    expect(result).toEqual({
+      "CONTEXT.$": `$$['Execution', 'State', 'StateMachine']`,
+    });
+  });
+
+  it("adds necessary fields to a non-empty payload", () => {
+    const payload = { "custom-key": "custom-value" };
+    const result = buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload);
+    expect(result).toEqual({
+      "custom-key": "custom-value",
+      "CONTEXT.$": `$$['Execution', 'State', 'StateMachine']`,
+    });
+  });
+
+  it("throws an error if payload already contains CONTEXT field", () => {
+    const payload = { CONTEXT: "value" };
+    expect(() => buildStepFunctionSfnExecutionTaskPayloadToMergeTraces(payload)).toThrowError(
+      "The StepFunction StartExecution task may be using custom CONTEXT field. Step Functions Context Object injection skipped. Your Step Functions trace will not be merged with downstream Lambda traces. Please open an issue in https://github.com/DataDog/datadog-cdk-constructs to discuss your workaround.",
     );
   });
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
Support merging Step Function traces with downstream StepFunction StartExecution task traces.
<!--- A brief description of the change being made with this pull request. --->

If the user constructs the task using:
```
    const invokeChildStateMachineTask = new tasks.StepFunctionsStartExecution(this, "InvokeChildStateMachineTask", {
      stateMachine: childStateMachine,
      input: sfn.TaskInput.fromObject(
        DatadogStepFunctions.buildStepFunctionTaskPayloadToMergeTraces({ "custom-key": "custom-value" }),
      ),
    });
```

then we will add these fields to the input to the State Machine:

```
"CONTEXT.$": "$$['Execution', 'State', 'StateMachine']"
```

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
### Testing Guidelines
#### Automated testing
Passed the added unit tests.

#### Manual testing
##### Steps
1. Deploy the example typescript step function stack
2. Run the State Machine once
##### Result
1. The `CONTEXT.$1 field is added to Step Function step input
<img width="453" alt="image" src="https://github.com/user-attachments/assets/176325ee-3ef3-453a-8f98-ed28b4d70fc8">
2. The flame graph of the step function also shows the flame graph of the inner step function

<img width="805" alt="Screenshot 2024-11-13 at 3 00 58 PM" src="https://github.com/user-attachments/assets/5537055d-5358-45cc-aa04-58d00994ab12">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
