### PR TITLE
chore: Make helpers take one, not multiple Lambda functions (3/x)

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -97,20 +97,20 @@ export class DatadogLambda extends Construct {
           this.props.useLayersFromAccount,
         );
       }
-    }
 
-    if (baseProps.extensionLayerVersion !== undefined) {
-      applyExtensionLayer(
-        this.scope,
-        region,
-        extractedLambdaFunctions,
-        baseProps.extensionLayerVersion,
-        this.props.useLayersFromAccount,
-      );
-    }
+      if (baseProps.extensionLayerVersion !== undefined) {
+        applyExtensionLayer(
+          this.scope,
+          region,
+          lambdaFunction,
+          baseProps.extensionLayerVersion,
+          this.props.useLayersFromAccount,
+        );
+      }
 
-    if (baseProps.redirectHandler) {
-      redirectHandlers(extractedLambdaFunctions, baseProps.addLayers);
+      if (baseProps.redirectHandler) {
+        redirectHandlers(lambdaFunction, baseProps.addLayers);
+      }
     }
 
     if (this.props.forwarderArn !== undefined) {

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -98,28 +98,26 @@ export function applyLayers(
 export function applyExtensionLayer(
   scope: Construct,
   region: string,
-  lambdas: lambda.Function[],
+  lam: lambda.Function,
   extensionLayerVersion: number,
   useLayersFromAccount?: string,
 ): string[] {
   // TODO: check region availability
   const errors: string[] = [];
-  log.debug("Applying extension layer to Lambda functions...");
-  lambdas.forEach((lam) => {
-    const runtime: string = lam.runtime.name;
-    const lambdaRuntimeType: RuntimeType = runtimeLookup[runtime];
-    const isARM = lam.architecture?.dockerPlatform === Architecture.ARM_64.dockerPlatform;
-    const accountId = useLayersFromAccount;
+  log.debug("Applying extension layer to Lambda function...");
+  const runtime: string = lam.runtime.name;
+  const lambdaRuntimeType: RuntimeType = runtimeLookup[runtime];
+  const isARM = lam.architecture?.dockerPlatform === Architecture.ARM_64.dockerPlatform;
+  const accountId = useLayersFromAccount;
 
-    if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
-      log.debug(`Unsupported runtime: ${runtime}`);
-      return;
-    }
+  if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
+    log.debug(`Unsupported runtime: ${runtime}`);
+    return errors;
+  }
 
-    const extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM, accountId);
-    log.debug(`Using extension layer: ${extensionLayerArn}`);
-    addLayer(extensionLayerArn, true, scope, lam, runtime);
-  });
+  const extensionLayerArn = getExtensionLayerArn(region, extensionLayerVersion, isARM, accountId);
+  log.debug(`Using extension layer: ${extensionLayerArn}`);
+  addLayer(extensionLayerArn, true, scope, lam, runtime);
   return errors;
 }
 

--- a/test/redirect.spec.ts
+++ b/test/redirect.spec.ts
@@ -24,7 +24,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers([hello], true);
+    redirectHandlers(hello, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${JS_HANDLER_WITH_LAYERS}`,
     });
@@ -42,7 +42,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers([hello], false);
+    redirectHandlers(hello, false);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${JS_HANDLER}`,
     });
@@ -60,7 +60,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers([hello], true);
+    redirectHandlers(hello, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${PYTHON_HANDLER}`,
     });
@@ -88,7 +88,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
       handler: "handleRequest",
     });
-    redirectHandlers([hello], true);
+    redirectHandlers(hello, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: "handleRequest",
     });
@@ -113,7 +113,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
       handler: "handleRequest",
     });
-    redirectHandlers([hello], true);
+    redirectHandlers(hello, true);
     Template.fromStack(stack).resourcePropertiesCountIs(
       "AWS::Lambda::Function",
       {
@@ -137,7 +137,7 @@ describe("redirectHandlers", () => {
     const hello = new lambda.DockerImageFunction(stack, "HelloHandler", {
       code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
     });
-    redirectHandlers([hello], true);
+    redirectHandlers(hello, true);
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: Match.absent(),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Context of this PR series

The end goal of this series of PRs is to abort the instrumentation of a Lambda function if its runtime is not supported, while still instrument other Lambda functions. More in https://github.com/DataDog/datadog-cdk-constructs/issues/314

However, this behavior is hard to implement under the current code structure:
```
public addLambdaFunctions() {
  grantReadLambdas(lambdas);
  applyLayers(lambdas);
  applyExtensionLayer(lambdas);
  ...
}
```

If one of the steps skips a Lambda function, it's hard for the subsequent steps to know this and thus skip the Lambda function.

Therefore, at the end of day, I'm going to change the code structure to:
```
public addLambdaFunctions() {
  for (lambda : lambdas) {
    addLambdaFunction(lambda);
  }
}

public addLambdaFunction() {
  if (!grantReadLambda(lambda)) {
    return;
  }

  if (!applyLayers(lambda)) {
    return;
  }
  ...
}
```

to make it possible to implement this behavior.

### What does this PR do?

This PR makes these helper functions to take a single Lambda function instead of multiple ones:
- `applyExtensionLayer()`
- `redirectHandlers()`

It's not supposed to change code behavior.

I'll handle other helper functions in separate PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines

Run snapshot tests: `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh` to ensure the generated CloudFormation template for the test stacks are not changed.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
