### PR TITLE
chore: Make helpers take one, not multiple Lambda functions (4/x)

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -111,22 +111,22 @@ export class DatadogLambda extends Construct {
       if (baseProps.redirectHandler) {
         redirectHandlers(lambdaFunction, baseProps.addLayers);
       }
-    }
 
-    if (this.props.forwarderArn !== undefined) {
-      if (this.props.extensionLayerVersion !== undefined) {
-        log.debug(`Skipping adding subscriptions to the lambda log groups since the extension is enabled`);
+      if (this.props.forwarderArn !== undefined) {
+        if (this.props.extensionLayerVersion !== undefined) {
+          log.debug(`Skipping adding subscriptions to the lambda log groups since the extension is enabled`);
+        } else {
+          log.debug(`Adding log subscriptions using provided Forwarder ARN: ${this.props.forwarderArn}`);
+          addForwarder(
+            this.scope,
+            lambdaFunction,
+            this.props.forwarderArn,
+            this.props.createForwarderPermissions === true,
+          );
+        }
       } else {
-        log.debug(`Adding log subscriptions using provided Forwarder ARN: ${this.props.forwarderArn}`);
-        addForwarder(
-          this.scope,
-          extractedLambdaFunctions,
-          this.props.forwarderArn,
-          this.props.createForwarderPermissions === true,
-        );
+        log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
       }
-    } else {
-      log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
     }
 
     addCdkConstructVersionTag(extractedLambdaFunctions);

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -27,19 +27,17 @@ function getForwarder(scope: Construct, forwarderArn: string) {
 
 export function addForwarder(
   scope: Construct,
-  lambdaFunctions: lambda.Function[],
+  lam: lambda.Function,
   forwarderArn: string,
   createForwarderPermissions: boolean,
 ): void {
   const forwarder = getForwarder(scope, forwarderArn);
   const forwarderDestination = new LambdaDestination(forwarder, { addPermissions: createForwarderPermissions });
-  lambdaFunctions.forEach((lam) => {
-    const subscriptionFilterName = generateSubscriptionFilterName(Names.uniqueId(lam), forwarderArn);
-    log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);
-    lam.logGroup.addSubscriptionFilter(subscriptionFilterName, {
-      destination: forwarderDestination,
-      filterPattern: FilterPattern.allEvents(),
-    });
+  const subscriptionFilterName = generateSubscriptionFilterName(Names.uniqueId(lam), forwarderArn);
+  log.debug(`Adding log subscription ${subscriptionFilterName} for ${lam.functionName}`);
+  lam.logGroup.addSubscriptionFilter(subscriptionFilterName, {
+    destination: forwarderDestination,
+    filterPattern: FilterPattern.allEvents(),
   });
 }
 

--- a/test/forwarder.spec.ts
+++ b/test/forwarder.spec.ts
@@ -22,7 +22,7 @@ describe("Forwarder for Lambda", () => {
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
-    addForwarder(stack, [nodeLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, nodeLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",
       FilterPattern: "",
@@ -47,7 +47,8 @@ describe("Forwarder for Lambda", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda, pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, nodeLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, pythonLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -74,8 +75,8 @@ describe("Forwarder for Lambda", () => {
       handler: "hello.handler",
     });
 
-    addForwarder(stack, [nodeLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
-    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:2", false);
+    addForwarder(stack, nodeLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, pythonLambda, "arn:test:forwarder:sa-east-1:12345678:2", false);
 
     const nodeLambdaSubscriptionFilters = findDatadogSubscriptionFilters(nodeLambda);
     const pythonLambdaSubscriptionFilters = findDatadogSubscriptionFilters(pythonLambda);
@@ -99,7 +100,7 @@ describe("Forwarder for Lambda", () => {
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
-      addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+      addForwarder(stack, pythonLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
 
       return stack;
     };
@@ -134,7 +135,8 @@ describe("Forwarder for Lambda", () => {
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
-      addForwarder(stack, [pythonLambda, nodeLambda], forwarderArn, false);
+      addForwarder(stack, pythonLambda, forwarderArn, false);
+      addForwarder(stack, nodeLambda, forwarderArn, false);
 
       return stack;
     };
@@ -252,7 +254,7 @@ describe("Forwarder for Lambda", () => {
         accessLogDestination: new LogGroupLogDestination(restLogGroup),
       },
     });
-    addForwarder(stack, [pythonLambda], "arn:test:forwarder:sa-east-1:12345678:1", false);
+    addForwarder(stack, pythonLambda, "arn:test:forwarder:sa-east-1:12345678:1", false);
     addForwarderToLogGroups(stack, [restLogGroup], "arn:test:forwarder:sa-east-1:12345678:2", false);
     Template.fromStack(stack).hasResourceProperties("AWS::Logs::SubscriptionFilter", {
       DestinationArn: "arn:test:forwarder:sa-east-1:12345678:1",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Context of this PR series

The end goal of this series of PRs is to abort the instrumentation of a Lambda function if its runtime is not supported, while still instrument other Lambda functions. More in https://github.com/DataDog/datadog-cdk-constructs/issues/314

However, this behavior is hard to implement under the current code structure:
```
public addLambdaFunctions() {
  grantReadLambdas(lambdas);
  applyLayers(lambdas);
  applyExtensionLayer(lambdas);
  ...
}
```

If one of the steps skips a Lambda function, it's hard for the subsequent steps to know this and thus skip the Lambda function.

Therefore, at the end of day, I'm going to change the code structure to:
```
public addLambdaFunctions() {
  for (lambda : lambdas) {
    addLambdaFunction(lambda);
  }
}

public addLambdaFunction() {
  if (!grantReadLambda(lambda)) {
    return;
  }

  if (!applyLayers(lambda)) {
    return;
  }
  ...
}
```

to make it possible to implement this behavior.

### What does this PR do?

This PR makes these helper functions to take a single Lambda function instead of multiple ones:
- `addForwarder()`

It's not supposed to change code behavior.

I'll handle other helper functions in separate PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines

Run snapshot tests: `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh` to ensure the generated CloudFormation template for the test stacks are not changed.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
