### PR TITLE
feat: Set DD_TRACE_ENABLED tag on state machine

### DIFF
--- a/integration_tests/snapshots/correct-step-function-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step-function-stack-snapshot.json
@@ -25,6 +25,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -113,6 +117,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -149,6 +157,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",
@@ -291,6 +303,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",
@@ -440,6 +456,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -476,6 +496,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",

--- a/integration_tests/snapshots/correct-step_functions_go_stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step_functions_go_stack-snapshot.json
@@ -25,6 +25,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -113,6 +117,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -149,6 +157,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",
@@ -292,6 +304,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",
@@ -441,6 +457,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -477,6 +497,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",

--- a/integration_tests/snapshots/correct-step_functions_python_stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step_functions_python_stack-snapshot.json
@@ -33,6 +33,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -121,6 +125,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -157,6 +165,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",
@@ -339,6 +351,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -486,6 +502,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
+     },
+     {
       "Key": "env",
       "Value": "dev"
      },
@@ -522,6 +542,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "DD_TRACE_ENABLED",
+      "Value": "true"
      },
      {
       "Key": "env",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,7 @@ export enum TagKeys {
   ENV = "env",
   SERVICE = "service",
   VERSION = "version",
+  DD_TRACE_ENABLED = "DD_TRACE_ENABLED",
 }
 
 export const runtimeLookup: { [key: string]: RuntimeType } = {

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -35,4 +35,12 @@ export function setTags(
       }
     });
   }
+
+  if (resource instanceof sfn.StateMachine) {
+    setStepFunctionTags(resource);
+  }
+}
+
+function setStepFunctionTags(stateMachine: sfn.StateMachine) {
+  Tags.of(stateMachine).add(TagKeys.DD_TRACE_ENABLED, "true");
 }

--- a/test/tags.spec.ts
+++ b/test/tags.spec.ts
@@ -189,6 +189,10 @@ describe("setTags for Step Function", () => {
           Value: "tag-value-2",
         },
         {
+          Key: "DD_TRACE_ENABLED",
+          Value: "true",
+        },
+        {
           Key: "env",
           Value: "dev",
         },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
When instrumenting a state machine, sets `DD_TRACE_ENABLED` tag to `true`. This is needed to enable tracing. 

Aligned with @nine5two7 that we always set it to true for now. If any customer wants to customize it, we can support it later.
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Automated testing
1. Passed the touched jest test.
2. Run `UPDATE_SNAPSHOTS=true aws-vault exec sso-serverless-sandbox-account-admin -- ./scripts/run_integration_tests.sh`, and the snapshots in the snapshot tests are updated.

#### Manual testing
##### Steps
1. Deploy the example stack `step-functions-typescript-stack`.
2. Run the state machine from AWS UI.
##### Result
1. On AWS UI, this tag is added:

<img width="638" alt="image" src="https://github.com/user-attachments/assets/9234ad3f-437f-45d9-8e8a-cfa8ec7e002c">

2. Traces are shown on Datadog app
<img width="1047" alt="image" src="https://github.com/user-attachments/assets/d4f296d9-3560-43e3-9b7c-a99f192bd52f">


<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
