### PR TITLE
feat: Set dd_cdk_construct version tag on state machine

### DIFF
--- a/integration_tests/snapshots/correct-step-function-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step-function-stack-snapshot.json
@@ -25,6 +25,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -117,6 +121,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -157,6 +165,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",
@@ -303,6 +315,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",
@@ -456,6 +472,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -496,6 +516,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",

--- a/integration_tests/snapshots/correct-step_functions_go_stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step_functions_go_stack-snapshot.json
@@ -25,6 +25,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -117,6 +121,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -157,6 +165,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",
@@ -304,6 +316,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",
@@ -457,6 +473,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -497,6 +517,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",

--- a/integration_tests/snapshots/correct-step_functions_python_stack-snapshot.json
+++ b/integration_tests/snapshots/correct-step_functions_python_stack-snapshot.json
@@ -33,6 +33,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -125,6 +129,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -165,6 +173,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",
@@ -351,6 +363,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -502,6 +518,10 @@
       "Value": "tag-value-2"
      },
      {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
+     },
+     {
       "Key": "DD_TRACE_ENABLED",
       "Value": "true"
      },
@@ -542,6 +562,10 @@
      {
       "Key": "custom-tag-2",
       "Value": "tag-value-2"
+     },
+     {
+      "Key": "dd_cdk_construct",
+      "Value": "vX.XX.X"
      },
      {
       "Key": "DD_TRACE_ENABLED",

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -12,6 +12,8 @@ import * as sfn from "aws-cdk-lib/aws-stepfunctions";
 import log from "loglevel";
 import { TagKeys, DatadogLambdaProps, DatadogStepFunctionsProps } from "./index";
 
+const versionJson = require("../version.json");
+
 export function setTags(
   resource: lambda.Function | sfn.StateMachine,
   props: DatadogLambdaProps | DatadogStepFunctionsProps,
@@ -43,4 +45,5 @@ export function setTags(
 
 function setStepFunctionTags(stateMachine: sfn.StateMachine) {
   Tags.of(stateMachine).add(TagKeys.DD_TRACE_ENABLED, "true");
+  Tags.of(stateMachine).add(TagKeys.CDK, `v${versionJson.version}`);
 }

--- a/test/tags.spec.ts
+++ b/test/tags.spec.ts
@@ -189,6 +189,10 @@ describe("setTags for Step Function", () => {
           Value: "tag-value-2",
         },
         {
+          Key: "dd_cdk_construct",
+          Value: `v${versionJson.version}`,
+        },
+        {
           Key: "DD_TRACE_ENABLED",
           Value: "true",
         },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
When instrumenting a state machine, set a tag like `dd_cdk_construct:1.19.0`, similar to the practice for Lambda in CDK and for Step Functions in CI (`dd_sls_ci` tag) and Serverless Plugin (`dd_sls_plugin` tag).
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
1. Passed the touched jest test
2. Updated the snapshots in snapshot tests
<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
