### PR TITLE
chore: Make helpers take one, not multiple Lambda functions (5/x)

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -127,11 +127,11 @@ export class DatadogLambda extends Construct {
       } else {
         log.debug("Forwarder ARN not provided, no log group subscriptions will be added");
       }
+
+      addCdkConstructVersionTag(lambdaFunction);
+      applyEnvVariables(lambdaFunction, baseProps);
     }
 
-    addCdkConstructVersionTag(extractedLambdaFunctions);
-
-    applyEnvVariables(extractedLambdaFunctions, baseProps);
     setDDEnvVariables(extractedLambdaFunctions, this.props);
     setTagsForFunctions(extractedLambdaFunctions, this.props);
 
@@ -170,12 +170,10 @@ export class DatadogLambda extends Construct {
   }
 }
 
-export function addCdkConstructVersionTag(lambdaFunctions: lambda.Function[]): void {
+export function addCdkConstructVersionTag(lambdaFunction: lambda.Function): void {
   log.debug(`Adding CDK Construct version tag: ${versionJson.version}`);
-  lambdaFunctions.forEach((functionName) => {
-    Tags.of(functionName).add(TagKeys.CDK, `v${versionJson.version}`, {
-      includeResourceTypes: ["AWS::Lambda::Function"],
-    });
+  Tags.of(lambdaFunction).add(TagKeys.CDK, `v${versionJson.version}`, {
+    includeResourceTypes: ["AWS::Lambda::Function"],
   });
 }
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -98,28 +98,26 @@ function filterSensitiveInfoFromRepository(repositoryUrl: string): string {
   }
 }
 
-export function applyEnvVariables(lambdas: lambda.Function[], baseProps: DatadogLambdaStrictProps): void {
+export function applyEnvVariables(lam: lambda.Function, baseProps: DatadogLambdaStrictProps): void {
   log.debug(`Setting environment variables...`);
-  lambdas.forEach((lam) => {
-    lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
-    lam.addEnvironment(ENABLE_DD_ASM_ENV_VAR, baseProps.enableDatadogASM.toString().toLowerCase());
-    if (baseProps.enableDatadogASM) {
-      lam.addEnvironment(AWS_LAMBDA_EXEC_WRAPPER_KEY, AWS_LAMBDA_EXEC_WRAPPER_VAL);
-    }
+  lam.addEnvironment(ENABLE_DD_TRACING_ENV_VAR, baseProps.enableDatadogTracing.toString().toLowerCase());
+  lam.addEnvironment(ENABLE_DD_ASM_ENV_VAR, baseProps.enableDatadogASM.toString().toLowerCase());
+  if (baseProps.enableDatadogASM) {
+    lam.addEnvironment(AWS_LAMBDA_EXEC_WRAPPER_KEY, AWS_LAMBDA_EXEC_WRAPPER_VAL);
+  }
 
-    lam.addEnvironment(ENABLE_XRAY_TRACE_MERGING_ENV_VAR, baseProps.enableMergeXrayTraces.toString().toLowerCase());
-    // Check for extensionLayerVersion and set INJECT_LOG_CONTEXT_ENV_VAR accordingly
-    if (baseProps.extensionLayerVersion) {
-      lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, "false");
-    } else {
-      lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, baseProps.injectLogContext.toString().toLowerCase());
-    }
-    lam.addEnvironment(ENABLE_DD_LOGS_ENV_VAR, baseProps.enableDatadogLogs.toString().toLowerCase());
-    lam.addEnvironment(CAPTURE_LAMBDA_PAYLOAD_ENV_VAR, baseProps.captureLambdaPayload.toString().toLowerCase());
-    if (baseProps.logLevel) {
-      lam.addEnvironment(LOG_LEVEL_ENV_VAR, baseProps.logLevel);
-    }
-  });
+  lam.addEnvironment(ENABLE_XRAY_TRACE_MERGING_ENV_VAR, baseProps.enableMergeXrayTraces.toString().toLowerCase());
+  // Check for extensionLayerVersion and set INJECT_LOG_CONTEXT_ENV_VAR accordingly
+  if (baseProps.extensionLayerVersion) {
+    lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, "false");
+  } else {
+    lam.addEnvironment(INJECT_LOG_CONTEXT_ENV_VAR, baseProps.injectLogContext.toString().toLowerCase());
+  }
+  lam.addEnvironment(ENABLE_DD_LOGS_ENV_VAR, baseProps.enableDatadogLogs.toString().toLowerCase());
+  lam.addEnvironment(CAPTURE_LAMBDA_PAYLOAD_ENV_VAR, baseProps.captureLambdaPayload.toString().toLowerCase());
+  if (baseProps.logLevel) {
+    lam.addEnvironment(LOG_LEVEL_ENV_VAR, baseProps.logLevel);
+  }
 }
 
 export function setDDEnvVariables(lambdas: lambda.Function[], props: DatadogLambdaProps): void {

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -267,7 +267,8 @@ describe("addCdkConstructVersionTag", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    addCdkConstructVersionTag([hello1, hello2]);
+    addCdkConstructVersionTag(hello1);
+    addCdkConstructVersionTag(hello2);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Runtime: "nodejs16.x",
       Tags: [


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Context of this PR series

The end goal of this series of PRs is to abort the instrumentation of a Lambda function if its runtime is not supported, while still instrument other Lambda functions. More in https://github.com/DataDog/datadog-cdk-constructs/issues/314

However, this behavior is hard to implement under the current code structure:
```
public addLambdaFunctions() {
  grantReadLambdas(lambdas);
  applyLayers(lambdas);
  applyExtensionLayer(lambdas);
  ...
}
```

If one of the steps skips a Lambda function, it's hard for the subsequent steps to know this and thus skip the Lambda function.

Therefore, at the end of day, I'm going to change the code structure to:
```
public addLambdaFunctions() {
  for (lambda : lambdas) {
    addLambdaFunction(lambda);
  }
}

public addLambdaFunction() {
  if (!grantReadLambda(lambda)) {
    return;
  }

  if (!applyLayers(lambda)) {
    return;
  }
  ...
}
```

to make it possible to implement this behavior.

### What does this PR do?

This PR makes these helper functions to take a single Lambda function instead of multiple ones:
- `addCdkConstructVersionTag()`
- `applyEnvVariables()`

It's not supposed to change code behavior.

I'll handle other helper functions in separate PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines

Run snapshot tests: `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh` to ensure the generated CloudFormation template for the test stacks are not changed.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
