### PR TITLE
chore: Make helpers take one, not multiple Lambda functions (6/x)

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -130,10 +130,9 @@ export class DatadogLambda extends Construct {
 
       addCdkConstructVersionTag(lambdaFunction);
       applyEnvVariables(lambdaFunction, baseProps);
+      setDDEnvVariables(lambdaFunction, this.props);
+      setTagsForFunction(lambdaFunction, this.props);
     }
-
-    setDDEnvVariables(extractedLambdaFunctions, this.props);
-    setTagsForFunctions(extractedLambdaFunctions, this.props);
 
     this.transport.applyEnvVars(extractedLambdaFunctions);
 
@@ -177,12 +176,10 @@ export function addCdkConstructVersionTag(lambdaFunction: lambda.Function): void
   });
 }
 
-function setTagsForFunctions(lambdaFunctions: lambda.Function[], props: DatadogLambdaProps): void {
-  lambdaFunctions.forEach((lambdaFunction) => {
-    if (props.forwarderArn) {
-      setTags(lambdaFunction, props);
-    }
-  });
+function setTagsForFunction(lambdaFunction: lambda.Function, props: DatadogLambdaProps): void {
+  if (props.forwarderArn) {
+    setTags(lambdaFunction, props);
+  }
 }
 
 function grantReadLambda(secret: ISecret, lambdaFunction: lambda.Function): void {

--- a/src/env.ts
+++ b/src/env.ts
@@ -120,42 +120,40 @@ export function applyEnvVariables(lam: lambda.Function, baseProps: DatadogLambda
   }
 }
 
-export function setDDEnvVariables(lambdas: lambda.Function[], props: DatadogLambdaProps): void {
-  lambdas.forEach((lam) => {
-    if (props.extensionLayerVersion) {
-      if (props.env) {
-        lam.addEnvironment(DD_ENV_ENV_VAR, props.env);
-      }
-      if (props.service) {
-        lam.addEnvironment(DD_SERVICE_ENV_VAR, props.service);
-      }
-      if (props.version) {
-        lam.addEnvironment(DD_VERSION_ENV_VAR, props.version);
-      }
-      if (props.tags) {
-        lam.addEnvironment(DD_TAGS, props.tags);
-      }
+export function setDDEnvVariables(lam: lambda.Function, props: DatadogLambdaProps): void {
+  if (props.extensionLayerVersion) {
+    if (props.env) {
+      lam.addEnvironment(DD_ENV_ENV_VAR, props.env);
     }
-    if (props.enableColdStartTracing !== undefined) {
-      lam.addEnvironment(DD_COLD_START_TRACING, props.enableColdStartTracing.toString().toLowerCase());
+    if (props.service) {
+      lam.addEnvironment(DD_SERVICE_ENV_VAR, props.service);
     }
-    if (props.minColdStartTraceDuration !== undefined) {
-      lam.addEnvironment(DD_MIN_COLD_START_DURATION, props.minColdStartTraceDuration.toString().toLowerCase());
+    if (props.version) {
+      lam.addEnvironment(DD_VERSION_ENV_VAR, props.version);
     }
-    if (props.coldStartTraceSkipLibs !== undefined) {
-      lam.addEnvironment(DD_COLD_START_TRACE_SKIP_LIB, props.coldStartTraceSkipLibs);
+    if (props.tags) {
+      lam.addEnvironment(DD_TAGS, props.tags);
     }
-    if (props.enableProfiling !== undefined) {
-      lam.addEnvironment(DD_PROFILING_ENABLED, props.enableProfiling.toString().toLowerCase());
-    }
-    if (props.encodeAuthorizerContext !== undefined) {
-      lam.addEnvironment(DD_ENCODE_AUTHORIZER_CONTEXT, props.encodeAuthorizerContext.toString().toLowerCase());
-    }
-    if (props.decodeAuthorizerContext !== undefined) {
-      lam.addEnvironment(DD_DECODE_AUTHORIZER_CONTEXT, props.decodeAuthorizerContext.toString().toLowerCase());
-    }
-    if (props.apmFlushDeadline !== undefined) {
-      lam.addEnvironment(DD_APM_FLUSH_DEADLINE_MILLISECONDS, props.apmFlushDeadline.toString().toLowerCase());
-    }
-  });
+  }
+  if (props.enableColdStartTracing !== undefined) {
+    lam.addEnvironment(DD_COLD_START_TRACING, props.enableColdStartTracing.toString().toLowerCase());
+  }
+  if (props.minColdStartTraceDuration !== undefined) {
+    lam.addEnvironment(DD_MIN_COLD_START_DURATION, props.minColdStartTraceDuration.toString().toLowerCase());
+  }
+  if (props.coldStartTraceSkipLibs !== undefined) {
+    lam.addEnvironment(DD_COLD_START_TRACE_SKIP_LIB, props.coldStartTraceSkipLibs);
+  }
+  if (props.enableProfiling !== undefined) {
+    lam.addEnvironment(DD_PROFILING_ENABLED, props.enableProfiling.toString().toLowerCase());
+  }
+  if (props.encodeAuthorizerContext !== undefined) {
+    lam.addEnvironment(DD_ENCODE_AUTHORIZER_CONTEXT, props.encodeAuthorizerContext.toString().toLowerCase());
+  }
+  if (props.decodeAuthorizerContext !== undefined) {
+    lam.addEnvironment(DD_DECODE_AUTHORIZER_CONTEXT, props.decodeAuthorizerContext.toString().toLowerCase());
+  }
+  if (props.apmFlushDeadline !== undefined) {
+    lam.addEnvironment(DD_APM_FLUSH_DEADLINE_MILLISECONDS, props.apmFlushDeadline.toString().toLowerCase());
+  }
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Context of this PR series

The end goal of this series of PRs is to abort the instrumentation of a Lambda function if its runtime is not supported, while still instrument other Lambda functions. More in https://github.com/DataDog/datadog-cdk-constructs/issues/314

However, this behavior is hard to implement under the current code structure:
```
public addLambdaFunctions() {
  grantReadLambdas(lambdas);
  applyLayers(lambdas);
  applyExtensionLayer(lambdas);
  ...
}
```

If one of the steps skips a Lambda function, it's hard for the subsequent steps to know this and thus skip the Lambda function.

Therefore, at the end of day, I'm going to change the code structure to:
```
public addLambdaFunctions() {
  for (lambda : lambdas) {
    addLambdaFunction(lambda);
  }
}

public addLambdaFunction() {
  if (!grantReadLambda(lambda)) {
    return;
  }

  if (!applyLayers(lambda)) {
    return;
  }
  ...
}
```

to make it possible to implement this behavior.

### What does this PR do?

This PR makes these helper functions to take a single Lambda function instead of multiple ones:
- `setDDEnvVariables()`
- `setTagsForFunctions()`

It's not supposed to change code behavior.

I'll handle other helper functions in separate PRs, to keep each PR small and easy to review.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines

Run snapshot tests: `aws-vault exec sso-serverless-sandbox-account-admin -- scripts/run_integration_tests.sh` to ensure the generated CloudFormation template for the test stacks are not changed.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
