### PR TITLE
fix: Abort instrumenting Lambda if runtime is unsupported

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -86,7 +86,7 @@ export class DatadogLambda extends Construct {
       }
 
       if (baseProps.addLayers) {
-        applyLayers(
+        const errors = applyLayers(
           this.scope,
           region,
           lambdaFunction,
@@ -96,16 +96,28 @@ export class DatadogLambda extends Construct {
           this.props.dotnetLayerVersion,
           this.props.useLayersFromAccount,
         );
+        if (errors.length > 0) {
+          log.warn(
+            `Failed to apply layers to the Lambda function ${lambdaFunction.functionName}. Skipping instrumenting it.`,
+          );
+          continue;
+        }
       }
 
       if (baseProps.extensionLayerVersion !== undefined) {
-        applyExtensionLayer(
+        const errors = applyExtensionLayer(
           this.scope,
           region,
           lambdaFunction,
           baseProps.extensionLayerVersion,
           this.props.useLayersFromAccount,
         );
+        if (errors.length > 0) {
+          log.warn(
+            `Failed to apply extention layer to the Lambda function ${lambdaFunction.functionName}. Skipping instrumenting it.`,
+          );
+          continue;
+        }
       }
 
       if (baseProps.redirectHandler) {

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -42,7 +42,9 @@ export function applyLayers(
   const isARM = lam.architecture?.dockerPlatform === Architecture.ARM_64.dockerPlatform;
 
   if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
-    log.debug(`Unsupported runtime: ${runtime}`);
+    const error = `Unsupported runtime: ${runtime}`;
+    log.warn(error);
+    errors.push(error);
     return errors;
   }
 
@@ -111,7 +113,9 @@ export function applyExtensionLayer(
   const accountId = useLayersFromAccount;
 
   if (lambdaRuntimeType === undefined || lambdaRuntimeType === RuntimeType.UNSUPPORTED) {
-    log.debug(`Unsupported runtime: ${runtime}`);
+    const error = `Unsupported runtime: ${runtime}`;
+    log.warn(error);
+    errors.push(error);
     return errors;
   }
 

--- a/test/layer.spec.ts
+++ b/test/layer.spec.ts
@@ -264,7 +264,8 @@ describe("applyLayers", () => {
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: Match.absent(),
     });
-    expect(errors.length).toEqual(0);
+    expect(errors.length).toEqual(1);
+    expect(errors[0]).toEqual("Unsupported runtime: go1.x");
   });
 
   it("doesn't add layer to container image Lambda without extension or layer versions", () => {


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
1. If Lambda runtime is unsupported, e.g. if it's an unresolved token, then abort instrumenting this Lambda function.
2. Change the required AWS CDK version from 2.134.0 to 2.146.0, so the unresolved token case can be tested.
<!--- A brief description of the change being made with this pull request. --->

### Motivation
Right now, even if Node runtime is not supported, we still proceed with the rest of the steps of instrumentation. As a result, Lambda execution may fail because it can't find a Datadog wrapper that's supposed to be in the Lambda layer.

More in https://github.com/DataDog/datadog-cdk-constructs/issues/314
<!--- What inspired you to submit this pull request? --->

### Testing Guidelines
#### Steps
1. Make changes on the example TypeScript Lambda stack, so it uses an unresolved runtime https://github.com/DataDog/datadog-cdk-constructs/commit/793365b7affd281dbb42d38f417c8ee76aeb4127
3. Deploy the stack

#### Result

1. A warning message is created:
<img width="651" alt="image" src="https://github.com/user-attachments/assets/61e0623d-76d7-421a-b050-df282731bfe9">

2. Lambda function doesn't have the two layers installed
3. Lambda could run with no error
<img width="535" alt="image" src="https://github.com/user-attachments/assets/2096bdff-a2c1-4aff-9f7a-808f5b493a33">

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
