### PR TITLE
chore: Change code owner to ONE team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @DataDog/serverless
+* @DataDog/serverless-onboarding-enablement
 
 # Documentation
 *.md  @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?
Changing code owner from Serverless team to serverless-onboarding-enablement subteam

### What and why?

1. Onboarding and Enablement team is a more specific owner. 
2. Team members will be added as a reviewer in a Round Robin way.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
