### PR TITLE
chore: Add git sha and url overrides

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -36,9 +36,21 @@ const execSync = require("child_process").execSync;
 
 const URL = require("url").URL;
 
-export function setGitEnvironmentVariables(lambdas: any[]): void {
+export function setGitEnvironmentVariables(
+  lambdas: any[],
+  gitCommitShaOverride?: string | undefined,
+  gitRepoUrlOverride?: string | undefined,
+): void {
   log.debug("Adding source code integration...");
-  const { hash, gitRepoUrl } = getGitData();
+  let { hash, gitRepoUrl } = getGitData();
+  if (gitCommitShaOverride) {
+    log.debug(`Using git SHA override.  Will be ${gitCommitShaOverride} instead of ${hash}`);
+    hash = gitCommitShaOverride;
+  }
+  if (gitRepoUrlOverride) {
+    log.debug(`Using git repo URL override.  Will be ${gitRepoUrlOverride} instead of ${hash}`);
+    gitRepoUrl = gitRepoUrlOverride;
+  }
 
   if (hash == "" || gitRepoUrl == "") return;
 

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -2,7 +2,13 @@ import { App, Stack, Token } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
-import { addCdkConstructVersionTag, checkForMultipleApiKeys, DatadogLambda, DD_HANDLER_ENV_VAR } from "../src/index";
+import {
+  addCdkConstructVersionTag,
+  checkForMultipleApiKeys,
+  DatadogLambda,
+  DD_HANDLER_ENV_VAR,
+  DD_TAGS,
+} from "../src/index";
 const { ISecret } = require("aws-cdk-lib/aws-secretsmanager");
 const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
@@ -560,5 +566,188 @@ describe("redirectHandler", () => {
         },
       },
     });
+  });
+});
+
+describe("overrideGitMetadata", () => {
+  it("overrides new lambda functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+    });
+    datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
+    datadogLambda.addLambdaFunctions([hello], stack);
+    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+      expect.arrayContaining(["git.commit.sha:fake-sha"]),
+    );
+    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+      expect.arrayContaining(["git.repository_url:fake-url"]),
+    );
+  });
+
+  it("overrides existing lambda functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+    });
+    datadogLambda.addLambdaFunctions([hello], stack);
+    datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
+    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+      expect.arrayContaining(["git.commit.sha:fake-sha"]),
+    );
+    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+      expect.arrayContaining(["git.repository_url:fake-url"]),
+    );
+  });
+  it("overrides both existing and new lambda functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const goodbye = new lambda.Function(stack, "GoodbyeHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+    });
+    datadogLambda.addLambdaFunctions([hello], stack);
+    datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
+    datadogLambda.addLambdaFunctions([goodbye], stack);
+
+    [hello, goodbye].forEach((f) => {
+      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+        expect.arrayContaining(["git.commit.sha:fake-sha"]),
+      );
+      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+        expect.arrayContaining(["git.repository_url:fake-url"]),
+      );
+    });
+  });
+
+  it("overrides only the sha for both existing and new lambda functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const goodbye = new lambda.Function(stack, "GoodbyeHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+      tags: "testVar:xyz",
+    });
+    datadogLambda.addLambdaFunctions([hello], stack);
+    datadogLambda.overrideGitMetadata("fake-sha");
+    datadogLambda.addLambdaFunctions([goodbye], stack);
+
+    [hello, goodbye].forEach((f) => {
+      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+        expect.arrayContaining(["git.commit.sha:fake-sha"]),
+      );
+      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(expect.arrayContaining(["testVar:xyz"]));
+    });
+  });
+
+  it("overrides only the sha for both existing and new lambda functions", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const goodbye = new lambda.Function(stack, "GoodbyeHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+    });
+    datadogLambda.addLambdaFunctions([hello], stack);
+    datadogLambda.overrideGitMetadata("fake-sha");
+    datadogLambda.addLambdaFunctions([goodbye], stack);
+
+    [hello, goodbye].forEach((f) => {
+      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+        expect.arrayContaining([
+          "git.commit.sha:fake-sha",
+          "git.repository_url:github.com/DataDog/datadog-cdk-constructs",
+        ]),
+      );
+    });
+  });
+
+  it("does not override when not called", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKey: "ABC",
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+      logLevel: "debug",
+    });
+    datadogLambda.addLambdaFunctions([hello], stack);
+
+    expect(
+      (<any>hello).environment[DD_TAGS].value.split(",").some((item: string) => item.includes("git.commit.sha")),
+    ).toEqual(true);
+    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+      expect.arrayContaining(["git.repository_url:github.com/DataDog/datadog-cdk-constructs"]),
+    );
   });
 });

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -656,7 +656,7 @@ describe("overrideGitMetadata", () => {
     });
   });
 
-  it("overrides only the sha for both existing and new lambda functions", () => {
+  it("overrides only the sha for both existing and new lambda functions while preserving existing tags", () => {
     const app = new App();
     const stack = new Stack(app, "stack");
     const hello = new lambda.Function(stack, "HelloHandler", {


### PR DESCRIPTION
### What does this PR do?

Add the ability to override the git sha and repo url to make snapshot testing easier.


### Motivation

<!--- What inspired you to submit this pull request? --->
Requested by a customer in  https://github.com/DataDog/datadog-cdk-constructs/issues/359

### Testing Guidelines

* Unit tests

### Additional Notes

This PR allows you to override the git commit sha without having to modify your stack code, other than making the datadog lambda public on your stack.  From a code snippet from the issue, adding the new line will make the snapshot consistent

```
test('Snapshot', () => {
  const app = new App();
  const stack = new SomeStack(app, 'test', {
    env: {
      account: '0123456789012',
      region: 'us-east-1',
    },
  });

  // New line
  stack.datadogLambda.overrideGitMetadata("fake-sha");

  const template = Template.fromStack(stack);
  expect(template.toJSON()).toMatchSnapshot();
});
```



### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
