### PR TITLE
fix: Change Python tarball name in publish_prod.sh

### DIFF
--- a/scripts/publish_prod.sh
+++ b/scripts/publish_prod.sh
@@ -106,7 +106,7 @@ if [ ! -f $PY_WHEEL ]; then
     exit 1
 fi
 
-PY_TARBALL=./dist/python/datadog-cdk-constructs-v2-$VERSION.tar.gz
+PY_TARBALL=./dist/python/datadog_cdk_constructs_v2-$VERSION.tar.gz
 if [ ! -f $PY_TARBALL ]; then
     echo "'${PY_TARBALL}' not found. Run 'yarn build' and ensure this file is created."
     exit 1


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Problem
After we updated various dependencies, the name of the tarball of Python package is changed from something like `datadog-cdk-constructs-v2-2.0.0.tar.gz` to `datadog_cdk_constructs_v2-2.0.0.tar.gz` (hyphen to underscore).
<img width="376" alt="image" src="https://github.com/user-attachments/assets/7d6d88d2-b9f6-44d6-86af-f4f2f40250bf" />

As a result, the `publish_prod.sh` script, which assumes the old name format, is not working properly.

<img width="759" alt="image" src="https://github.com/user-attachments/assets/823e9bcb-2fd0-48a7-8af5-c9a37c6dafbb" />

### What does this PR do?

Updates the expected Python tarball name to be consistent with its real new name.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

To test in prod by releasing v2-2.0.0.

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
