### PR TITLE
chore: Use Node 18 in tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Enable X-Ray Tracing on your Lambda functions. For more information, see [CDK do
 import * as lambda from "aws-cdk-lib/aws-lambda";
 
 const lambda_function = new lambda.Function(this, "HelloHandler", {
-  runtime: lambda.Runtime.NODEJS_14_X,
+  runtime: lambda.Runtime.NODEJS_18_X,
   code: lambda.Code.fromAsset("lambda"),
   handler: "hello.handler",
   tracing: lambda.Tracing.ACTIVE,

--- a/integration_tests/snapshots/correct-lambda-function-arm-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-lambda-function-arm-stack-snapshot.json
@@ -59,7 +59,7 @@
     },
     "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
     "Layers": [
-     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension-ARM:10"
     ],
     "Role": {
@@ -68,7 +68,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs14.x",
+    "Runtime": "nodejs18.x",
     "Tags": [
      {
       "Key": "dd_cdk_construct",

--- a/integration_tests/snapshots/correct-lambda-function-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-lambda-function-stack-snapshot.json
@@ -56,7 +56,7 @@
     },
     "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
     "Layers": [
-     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
     "Role": {
@@ -65,7 +65,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs14.x",
+    "Runtime": "nodejs18.x",
     "Tags": [
      {
       "Key": "dd_cdk_construct",

--- a/integration_tests/snapshots/correct-lambda-nodejs-function-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-lambda-nodejs-function-stack-snapshot.json
@@ -43,7 +43,6 @@
     },
     "Environment": {
      "Variables": {
-      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
       "DD_LAMBDA_HANDLER": "index.handler",
       "DD_TRACE_ENABLED": "true",
       "DD_SERVERLESS_APPSEC_ENABLED": "false",
@@ -58,7 +57,7 @@
     },
     "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
     "Layers": [
-     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
     "Role": {
@@ -67,7 +66,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs14.x",
+    "Runtime": "nodejs18.x",
     "Tags": [
      {
       "Key": "dd_cdk_construct",

--- a/integration_tests/snapshots/correct-lambda-singleton-function-stack-snapshot.json
+++ b/integration_tests/snapshots/correct-lambda-singleton-function-stack-snapshot.json
@@ -56,7 +56,7 @@
     },
     "Handler": "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler",
     "Layers": [
-     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node14-x:XXX",
+     "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Node18-x:XXX",
      "arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-Extension:XXX"
     ],
     "Role": {
@@ -65,7 +65,7 @@
       "Arn"
      ]
     },
-    "Runtime": "nodejs14.x",
+    "Runtime": "nodejs18.x",
     "Tags": [
      {
       "Key": "dd_cdk_construct",

--- a/integration_tests/stacks/typescript/lambda-function-arm-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-function-arm-stack.ts
@@ -18,7 +18,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaFunction = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "lambdaFunction.handler",
       architecture: Architecture.ARM_64,

--- a/integration_tests/stacks/typescript/lambda-function-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-function-stack.ts
@@ -17,7 +17,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaFunction = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "lambdaFunction.handler",
     });

--- a/integration_tests/stacks/typescript/lambda-nodejs-function-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-nodejs-function-stack.ts
@@ -18,7 +18,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaNodejsFunction = new NodejsFunction(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       entry: __dirname + "/../../lambda/example-lambda.js",
       handler: "handler",
     });

--- a/integration_tests/stacks/typescript/lambda-singleton-function-stack.ts
+++ b/integration_tests/stacks/typescript/lambda-singleton-function-stack.ts
@@ -17,7 +17,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const singletonLambdaFunction = new lambda.SingletonFunction(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "lambdaFunction.handler",
       uuid: "b55587fe-6985-4c28-ab51-4d0edb1ba8a1",

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -171,7 +171,7 @@ for ((i = 0; i < ${#STACK_CONFIG_PATHS[@]}; i++)); do
     # Normalize Metadata aws:asset:original-path
     perl -p -i -e 's/("aws:asset:original-path": )"(.+)"/$1\"XXXXXXXXXXXXX\"/g' ${RAW_CFN_TEMPLATE}
     # Normalize Datadog Layer Arn versions
-    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-(Python27|Python36|Python37|Python38|Python39|Node12-x|Node14-x|Extension):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-\2:XXX/g' ${RAW_CFN_TEMPLATE}
+    perl -p -i -e 's/(arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-(Python27|Python36|Python37|Python38|Python39|Node18-x|Extension):\d+)/arn:aws:lambda:sa-east-1:464622532012:layer:Datadog-\2:XXX/g' ${RAW_CFN_TEMPLATE}
     # Normalize API Gateway timestamps
     perl -p -i -e 's/("ApiGatewayDeployment.*")/"ApiGatewayDeploymentxxxx"/g' ${RAW_CFN_TEMPLATE}
     # Normalize Subscription Filter name

--- a/src/sample/index.ts
+++ b/src/sample/index.ts
@@ -20,13 +20,13 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaFunction = new lambda.Function(this, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("./src/sample/lambda"),
       handler: "lambdaFunction.handler",
     });
 
     const lambdaNodejsFunction = new lambdaNodejs.NodejsFunction(this, "NodeJSHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       entry: "./src/sample/lambda_nodejs/hello_node.js",
       handler: "handler",
     });
@@ -48,7 +48,7 @@ export class ExampleStack extends Stack {
     });
 
     const lambdaFunction1 = new lambda.Function(this, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("./src/sample/lambda"),
       handler: "lambdaFunction.handler",
     });

--- a/src/sample/index_cdk_v2_test.ts
+++ b/src/sample/index_cdk_v2_test.ts
@@ -16,7 +16,7 @@ export class ExampleStack extends Stack {
     super(scope, id, props);
 
     const lambdaNodejsFunction = new lambdaNodejs.NodejsFunction(this, "NodeJSHandler", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       entry: "./src/sample/lambda_nodejs/hello_node.js",
       handler: "handler",
     });

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -23,7 +23,7 @@ describe("validateProps", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -60,7 +60,7 @@ describe("validateProps", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -95,7 +95,7 @@ describe("validateProps", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -126,7 +126,7 @@ describe("validateProps", () => {
     const app = new App();
     const stack = new Stack(app, "stack");
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -167,7 +167,7 @@ describe("validateProps", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -191,7 +191,7 @@ describe("validateProps", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -264,7 +264,7 @@ describe("addCdkConstructVersionTag", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -276,7 +276,7 @@ describe("addCdkConstructVersionTag", () => {
     addCdkConstructVersionTag(hello1);
     addCdkConstructVersionTag(hello2);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Runtime: "nodejs16.x",
+      Runtime: "nodejs18.x",
       Tags: [
         {
           Key: "dd_cdk_construct",
@@ -302,7 +302,7 @@ describe("addCdkConstructVersionTag", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -393,7 +393,7 @@ describe("apiKeySecret", () => {
     const app = new App();
     const stack = new Stack(app, "stack");
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -417,7 +417,7 @@ describe("apiKeySecret", () => {
     const app = new App();
     const stack = new Stack(app, "stack");
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -529,7 +529,7 @@ describe("redirectHandler", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -552,7 +552,7 @@ describe("redirectHandler", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });

--- a/test/env.spec.ts
+++ b/test/env.spec.ts
@@ -33,7 +33,7 @@ describe("applyEnvVariables", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -66,7 +66,7 @@ describe("applyEnvVariables", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -101,7 +101,7 @@ describe("applyEnvVariables", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -138,7 +138,7 @@ describe("setDDEnvVariables", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -188,7 +188,7 @@ describe("ENABLE_DD_TRACING_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -219,7 +219,7 @@ describe("ENABLE_DD_TRACING_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -249,7 +249,7 @@ describe("ENABLE_XRAY_TRACE_MERGING_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -281,7 +281,7 @@ describe("ENABLE_XRAY_TRACE_MERGING_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -312,7 +312,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -345,7 +345,7 @@ describe("INJECT_LOG_CONTEXT_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -378,7 +378,7 @@ describe("LOG_LEVEL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -414,7 +414,7 @@ describe("ENABLE_DD_LOGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -445,7 +445,7 @@ describe("ENABLE_DD_LOGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -475,7 +475,7 @@ describe("DD_TAGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -507,7 +507,7 @@ describe("DD_TAGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -546,7 +546,7 @@ describe("DD_TAGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -580,7 +580,7 @@ describe("CAPTURE_LAMBDA_PAYLOAD_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -611,7 +611,7 @@ describe("CAPTURE_LAMBDA_PAYLOAD_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });

--- a/test/forwarder.spec.ts
+++ b/test/forwarder.spec.ts
@@ -18,7 +18,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -37,7 +37,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -65,7 +65,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -131,7 +131,7 @@ describe("Forwarder for Lambda", () => {
         handler: "hello.handler",
       });
       const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-        runtime: lambda.Runtime.NODEJS_16_X,
+        runtime: lambda.Runtime.NODEJS_18_X,
         code: lambda.Code.fromAsset("test"),
         handler: "hello.handler",
       });
@@ -167,7 +167,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const pythonLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -206,7 +206,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -243,7 +243,7 @@ describe("Forwarder for Lambda", () => {
       },
     });
     const pythonLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -277,7 +277,7 @@ describe("Forwarder for State Machine", () => {
     });
     const logGroup = new LogGroup(stack, "logGroup");
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -25,7 +25,7 @@ describe("addLambdaFunctions", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -71,7 +71,7 @@ describe("addLambdaFunctions", () => {
       },
     });
     const nodeLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -101,7 +101,7 @@ describe("addLambdaFunctions", () => {
     const NestStack = new NestedStack(RootStack, "NestedStack");
 
     const NestedStackLambda = new lambda.Function(NestStack, "NestedStackLambda", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -133,7 +133,7 @@ describe("addLambdaFunctions", () => {
     const NestStack = new NestedStack(RootStack, "NestedStack");
 
     const NestedStackLambda = new lambda.Function(NestStack, "NestedStackLambda", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -152,7 +152,7 @@ describe("addLambdaFunctions", () => {
 
     Template.fromStack(NestStack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: [
-        `arn:aws:lambda:sa-east-1:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:20`,
+        `arn:aws:lambda:sa-east-1:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:20`,
         `arn:aws:lambda:sa-east-1:${DD_ACCOUNT_ID}:layer:Datadog-Extension:6`,
       ],
     });
@@ -168,7 +168,7 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -203,7 +203,7 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });

--- a/test/layer.spec.ts
+++ b/test/layer.spec.ts
@@ -27,13 +27,13 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
     const errors = applyLayers(stack, stack.region, hello, PYTHON_LAYER_VERSION, NODE_LAYER_VERSION);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
     expect(errors.length).toEqual(0);
   });
@@ -46,7 +46,7 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
@@ -62,7 +62,7 @@ describe("applyLayers", () => {
     datadogLambda.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: [
-        `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`,
+        `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`,
         `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension:${EXTENSION_LAYER_VERSION}`,
       ],
     });
@@ -76,7 +76,7 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
@@ -102,7 +102,7 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
       architecture: Architecture.ARM_64,
@@ -120,7 +120,7 @@ describe("applyLayers", () => {
     datadogLambda.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: [
-        `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`,
+        `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`,
         `arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Extension-ARM:${EXTENSION_LAYER_VERSION}`,
       ],
     });
@@ -195,14 +195,14 @@ describe("applyLayers", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
     (hello as any).architecture = undefined;
     const errors = applyLayers(stack, stack.region, hello, PYTHON_LAYER_VERSION, NODE_LAYER_VERSION);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
     expect(errors.length).toEqual(0);
   });
@@ -215,17 +215,17 @@ describe("applyLayers", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
     const hello2 = new lambda.Function(stack, "HelloHandler2", {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
     const hello3 = new lambda.Function(stack, "HelloHandler3", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
@@ -238,13 +238,13 @@ describe("applyLayers", () => {
     expect(errors2.length).toEqual(0);
     expect(errors3.length).toEqual(0);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node14-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws:lambda:${stack.region}:${DD_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
   });
 
@@ -390,7 +390,7 @@ describe("applyLayers", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -420,7 +420,7 @@ describe("isGovCloud", () => {
       },
     });
     const pythonLambda = new lambda.Function(stack, "NodeHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test"),
       handler: "hello.handler",
     });
@@ -441,7 +441,7 @@ describe("isGovCloud", () => {
       ],
     });
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Layers: [`arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`],
+      Layers: [`arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`],
     });
   });
 
@@ -453,7 +453,7 @@ describe("isGovCloud", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset("test/lambda"),
       handler: "example-lambda.handler",
     });
@@ -469,7 +469,7 @@ describe("isGovCloud", () => {
     datadogLambda.addLambdaFunctions([hello]);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Layers: [
-        `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node16-x:${NODE_LAYER_VERSION}`,
+        `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Node18-x:${NODE_LAYER_VERSION}`,
         `arn:aws-us-gov:lambda:us-gov-east-1:${DD_GOV_ACCOUNT_ID}:layer:Datadog-Extension:${EXTENSION_LAYER_VERSION}`,
       ],
     });

--- a/test/tags.spec.ts
+++ b/test/tags.spec.ts
@@ -19,7 +19,7 @@ describe("setTags for Lambda", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -47,7 +47,7 @@ describe("setTags for Lambda", () => {
     datadogLambda.addLambdaFunctions([hello1, hello2]);
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Runtime: "nodejs16.x",
+      Runtime: "nodejs18.x",
       Tags: [
         {
           Key: "dd_cdk_construct",
@@ -113,7 +113,7 @@ describe("setTags for Lambda", () => {
       },
     });
     const hello1 = new lambda.Function(stack, "HelloHandler1", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -140,7 +140,7 @@ describe("setTags for Lambda", () => {
     datadogLambda.addLambdaFunctions([hello1, hello2]);
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
-      Runtime: "nodejs16.x",
+      Runtime: "nodejs18.x",
       Tags: [
         {
           Key: "dd_cdk_construct",

--- a/test/transport.spec.ts
+++ b/test/transport.spec.ts
@@ -27,7 +27,7 @@ describe("SITE_URL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -63,7 +63,7 @@ describe("SITE_URL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -98,7 +98,7 @@ describe("SITE_URL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -132,7 +132,7 @@ describe("SITE_URL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -167,7 +167,7 @@ describe("SITE_URL_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -202,7 +202,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -238,7 +238,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -269,7 +269,7 @@ describe("FLUSH_METRICS_TO_LOGS_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -306,7 +306,7 @@ describe("API_KEY_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -344,7 +344,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -380,7 +380,7 @@ describe("API_KEY_SECRET_ARN_ENV_VAR", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
@@ -441,7 +441,7 @@ describe("apiKMSKeyEnvVar", () => {
       },
     });
     const hello = new lambda.Function(stack, "HelloHandler", {
-      runtime: lambda.Runtime.NODEJS_16_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

The latest version of CDK Construct requires node.js version 18.18 or above, but many tests and examples are still using v14 or v16. This PR makes them use v18.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

Passed all unit tests and integration tests.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
