### PR TITLE
feat: Add context variable for git sha override

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -40,6 +40,7 @@ export class DatadogLambda extends Construct {
   gitCommitShaOverride: string | undefined;
   gitRepoUrlOverride: string | undefined;
   lambdas: LambdaFunction[];
+  contextGitShaOverrideKey: string = "datadog-lambda.git-commit-sha-override";
 
   constructor(scope: Construct, id: string, props: DatadogLambdaProps) {
     if (process.env.DD_CONSTRUCT_DEBUG_LOGS?.toLowerCase() === "true") {
@@ -62,6 +63,11 @@ export class DatadogLambda extends Construct {
       this.props.apiKmsKey,
       this.props.extensionLayerVersion,
     );
+
+    const gitCommitShaOverride = this.node.tryGetContext(this.contextGitShaOverrideKey);
+    if (gitCommitShaOverride) {
+      this.overrideGitMetadata(gitCommitShaOverride);
+    }
   }
 
   public addLambdaFunctions(lambdaFunctions: LambdaFunction[], construct?: Construct): void {


### PR DESCRIPTION




<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add the ability to also use a context variable for the git SHA override so there isn't a need to expose the datadog lambda on the stack.

### Motivation

Issue: https://github.com/DataDog/datadog-cdk-constructs/issues/359

### Testing Guidelines

All automated tests still pass, added a unit test for this

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
