### PR TITLE
fix: Fix go package publish for v2-2.x.x

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -22,7 +22,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   publishToGo: {
     moduleName: "github.com/DataDog/datadog-cdk-constructs-go",
-    packageName: "ddcdkconstruct/v2",
+    packageName: "ddcdkconstruct",
   },
   peerDeps: [],
   cdkVersion: "2.177.0",

--- a/examples/go-stack/.gitignore
+++ b/examples/go-stack/.gitignore
@@ -18,3 +18,6 @@ app
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+# The copied Go package for dev testing
+ddcdkconstruct/

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
       },
       "go": {
         "moduleName": "github.com/DataDog/datadog-cdk-constructs-go",
-        "packageName": "ddcdkconstruct/v2"
+        "packageName": "ddcdkconstruct"
       }
     },
     "tsc": {


### PR DESCRIPTION
### Motivation

<!--- What inspired you to submit this pull request? --->

Go package fails to be published. When I run `publish_prod.sh`, this line:

https://github.com/DataDog/datadog-cdk-constructs/blob/a647447a3d5539cba7614d7bf78695aeac675877/scripts/publish_prod.sh#L127

prints:

> No modules detected. Skipping

This is because https://github.com/DataDog/datadog-cdk-constructs/pull/366 incorrectly added `/v2` suffix to the `moduleName`:

https://github.com/DataDog/datadog-cdk-constructs/blob/a647447a3d5539cba7614d7bf78695aeac675877/.projenrc.js#L23-L26

Now it doesn't seem to me that the `/v2` suffix is needed.

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Remove the `/v2` suffix from Go moduleName to fix Go package publish.

<!--- A brief description of the change being made with this pull request. --->

### Testing Guidelines
#### Publish package
Steps:
1. Run `GITHUB_TOKEN=$GITHUB_TOKEN npx -p publib@latest publib-golang`. 

Result:
1. A commit with tag `ddcdkconstruct/v2.2.0` is pushed to `datadog-cdk-constructs-go` repo: https://github.com/DataDog/datadog-cdk-constructs-go/releases/tag/ddcdkconstruct%2Fv2.2.0
2. The package appeared on pkg.go.dev: https://pkg.go.dev/github.com/DataDog/datadog-cdk-constructs-go/ddcdkconstruct/v2@v2.2.0

#### Integration Test
Snapshot tests `run_integration_tests.sh` passed

#### Use remote package in stack
Steps:
1. In `go.mod` of the example stack `go-stack`, update the package version to:
```
github.com/DataDog/datadog-cdk-constructs-go/ddcdkconstruct/v2 v2.2.0
```
2. Run `go get`
3. Deploy: `aws-vault exec sso-serverless-sandbox-account-admin -- cdk deploy --all`

Result:
- Deployment is successful

#### Use local package in stack

Steps:
1. Follow the steps here to install the local package to the example stack `go-stack`: https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723906703/Datadog+CDK+Constructs#Go
2. Deploy: `aws-vault exec sso-serverless-sandbox-account-admin -- cdk deploy --all`

Result:
- Deployment is successful

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
