### PR TITLE
chore: Change dependency upgrade workflow from daily to weekly

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,7 +4,7 @@ name: upgrade
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -79,6 +79,11 @@ const project = new awscdk.AwsCdkConstructLibrary({
   mergify: false,
   licensed: true,
   docgen: false,
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: javascript.UpgradeDependenciesSchedule.WEEKLY,
+    },
+  },
 });
 const eslintConfig = project.tryFindObjectFile(".eslintrc.json");
 eslintConfig.addOverride("extends", [


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### Motivation

<!--- What inspired you to submit this pull request? --->

Right now the `upgrade.yml` workflow runs every day, which creates a PR `chore(deps): upgrade dependencies` almost every day, which I think is too frequent.

Sample PRs:
https://github.com/DataDog/datadog-cdk-constructs/pull/389
https://github.com/DataDog/datadog-cdk-constructs/pull/386
https://github.com/DataDog/datadog-cdk-constructs/pull/385
https://github.com/DataDog/datadog-cdk-constructs/pull/384
https://github.com/DataDog/datadog-cdk-constructs/pull/382

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Changes the frequency to weekly on Monday.

### Testing Guidelines

<!--- How did you test this pull request? --->

The generated `upgrade.yml` is updated.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
