### PR TITLE
chore(test): DatadogECSFargate unit test coverage

### DIFF
--- a/test/ecs/fargate/apm-dsd.spec.ts
+++ b/test/ecs/fargate/apm-dsd.spec.ts
@@ -168,4 +168,58 @@ describe("DatadogECSFargateTaskDefinition", () => {
       ]),
     });
   });
+
+  it("should enable origin detection when isOriginDetectionEnabled is true", () => {
+    datadogProps = {
+      ...datadogProps,
+      dogstatsd: {
+        isEnabled: true,
+        isOriginDetectionEnabled: true,
+      },
+    };
+    const taskDefinition = new ecsDatadog.DatadogECSFargateTaskDefinition(scope, id, props, datadogProps);
+    const template = Template.fromStack(stack);
+
+    // Validate that the environment variable for origin detection is added
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: taskDefinition.datadogContainer.containerName,
+          Environment: Match.arrayWith([
+            Match.objectLike({
+              Name: "DD_DOGSTATSD_ORIGIN_DETECTION",
+              Value: "true",
+            }),
+          ]),
+        }),
+      ]),
+    });
+  });
+
+  it("should set the DogStatsD cardinality when dogstatsdCardinality is configured", () => {
+    datadogProps = {
+      ...datadogProps,
+      dogstatsd: {
+        isEnabled: true,
+        dogstatsdCardinality: ecsDatadog.Cardinality.LOW,
+      },
+    };
+    const taskDefinition = new ecsDatadog.DatadogECSFargateTaskDefinition(scope, id, props, datadogProps);
+    const template = Template.fromStack(stack);
+
+    // Validate that the environment variable for DogStatsD cardinality is added
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: taskDefinition.datadogContainer.containerName,
+          Environment: Match.arrayWith([
+            Match.objectLike({
+              Name: "DD_DOGSTATSD_TAG_CARDINALITY",
+              Value: ecsDatadog.Cardinality.LOW,
+            }),
+          ]),
+        }),
+      ]),
+    });
+  });
 });

--- a/test/ecs/fargate/logging.spec.ts
+++ b/test/ecs/fargate/logging.spec.ts
@@ -177,4 +177,34 @@ describe("DatadogECSFargateLogging", () => {
       ]),
     });
   });
+
+  it("configures the log container with provided values", () => {
+    datadogProps = {
+      ...datadogProps,
+      logCollection: {
+        isEnabled: true,
+        cpu: 256,
+        memoryLimitMiB: 2048,
+        logDriverConfiguration: {
+          registry: "public.ecr.aws/aws-observability/aws-for-fluent-bit",
+          imageVersion: "stable",
+        },
+      },
+    };
+
+    const task = new ecsDatadog.DatadogECSFargateTaskDefinition(scope, id, props, datadogProps);
+    const template = Template.fromStack(stack);
+
+    // Validate that the log container is configured with the custom cpu and memory values
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Name: task.logContainer!.containerName,
+          Cpu: 256,
+          Memory: 2048,
+          Image: "public.ecr.aws/aws-observability/aws-for-fluent-bit:stable",
+        }),
+      ]),
+    });
+  });
 });

--- a/test/ecs/fargate/utils.spec.ts
+++ b/test/ecs/fargate/utils.spec.ts
@@ -1,0 +1,51 @@
+import { LoggingType } from "../../../src/ecs/fargate/interfaces";
+import { validateECSFargateProps } from "../../../src/ecs/fargate/utils";
+
+describe("validateECSFargateProps", () => {
+  let props: any;
+
+  beforeEach(() => {
+    props = {
+      logCollection: {
+        isEnabled: true,
+        loggingType: LoggingType.FLUENTBIT,
+        logDriverConfiguration: {
+          registry: "public.ecr.aws/aws-observability/aws-for-fluent-bit",
+          imageVersion: "stable",
+        },
+      },
+      isLinux: true,
+    };
+  });
+
+  it("should not throw an error when all required fields are valid", () => {
+    expect(() => validateECSFargateProps(props)).not.toThrow();
+  });
+
+  it("should throw an error if logCollection is undefined", () => {
+    delete props.logCollection;
+    expect(() => validateECSFargateProps(props)).toThrow();
+  });
+
+  it("should throw an error if loggingType is undefined when logging is enabled", () => {
+    delete props.logCollection.loggingType;
+    expect(() => validateECSFargateProps(props)).toThrow();
+  });
+
+  it("should throw an error if logDriverConfiguration is undefined when logging is enabled", () => {
+    delete props.logCollection.logDriverConfiguration;
+    expect(() => validateECSFargateProps(props)).toThrow();
+  });
+
+  it("should throw an error if Fluent Bit logging is enabled but the operating system is not Linux", () => {
+    props.isLinux = false;
+    expect(() => validateECSFargateProps(props)).toThrow();
+  });
+
+  it("should not throw an error if logging is disabled", () => {
+    props.logCollection.isEnabled = false;
+    delete props.logCollection.loggingType;
+    delete props.logCollection.logDriverConfiguration;
+    expect(() => validateECSFargateProps(props)).not.toThrow();
+  });
+});

--- a/test/ecs/utils.spec.ts
+++ b/test/ecs/utils.spec.ts
@@ -1,0 +1,166 @@
+import * as cdk from "aws-cdk-lib";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { Construct } from "constructs";
+import {
+  validateECSBaseProps,
+  isOperatingSystemLinux,
+  getSecretApiKey,
+  addCdkConstructVersionTag,
+} from "../../src/ecs/utils";
+
+describe("utils", () => {
+  let app: cdk.App;
+  let stack: cdk.Stack;
+  let scope: Construct;
+  let task: ecs.TaskDefinition;
+
+  beforeEach(() => {
+    app = new cdk.App();
+    stack = new cdk.Stack(app, "TestStack");
+    scope = new Construct(stack, "TestScope");
+    task = new ecs.TaskDefinition(scope, "TestTask", {
+      compatibility: ecs.Compatibility.FARGATE,
+      cpu: "256",
+      memoryMiB: "512",
+    });
+  });
+
+  describe("validateECSBaseProps", () => {
+    it("should not throw an error for valid props", () => {
+      const props = {
+        site: "datadoghq.com",
+        dogstatsd: {},
+        apm: {},
+        cws: {},
+        registry: "public.ecr.aws/datadog/agent",
+        imageVersion: "latest",
+      };
+      expect(() => validateECSBaseProps(props)).not.toThrow();
+    });
+
+    it("should throw an error if site is invalid", () => {
+      const props = {
+        site: "invalid-site",
+        dogstatsd: {},
+        apm: {},
+        cws: {},
+        registry: "public.ecr.aws/datadog/agent",
+        imageVersion: "latest",
+      };
+      expect(() => validateECSBaseProps(props)).toThrow();
+    });
+
+    it("should throw an error if a feature (dogstatsd) is undefined", () => {
+      const props = {
+        site: "datadoghq.com",
+        apm: {},
+        cws: {},
+        registry: "public.ecr.aws/datadog/agent",
+        imageVersion: "latest",
+      };
+      expect(() => validateECSBaseProps(props)).toThrow();
+    });
+
+    it("should throw an error if registry is undefined", () => {
+      const props = {
+        site: "datadoghq.com",
+        dogstatsd: {},
+        apm: {},
+        cws: {},
+        imageVersion: "latest",
+      };
+      expect(() => validateECSBaseProps(props)).toThrow();
+    });
+
+    it("should throw an error if imageVersion is undefined", () => {
+      const props = {
+        site: "datadoghq.com",
+        dogstatsd: {},
+        apm: {},
+        cws: {},
+        registry: "public.ecr.aws/datadog/agent",
+      };
+      expect(() => validateECSBaseProps(props)).toThrow();
+    });
+
+    it("should throw an error if datadog dependency is enabled but health check is not defined", () => {
+      const props = {
+        site: "datadoghq.com",
+        dogstatsd: {},
+        apm: {},
+        cws: {},
+        registry: "public.ecr.aws/datadog/agent",
+        imageVersion: "latest",
+        isDatadogDependencyEnabled: true,
+      };
+      expect(() => validateECSBaseProps(props)).toThrow();
+    });
+  });
+
+  describe("isOperatingSystemLinux", () => {
+    it("should return true if runtimePlatform is undefined", () => {
+      const props = {};
+      expect(isOperatingSystemLinux(props)).toBe(true);
+    });
+
+    it("should return true if operatingSystemFamily is undefined", () => {
+      const props = { runtimePlatform: {} };
+      expect(isOperatingSystemLinux(props)).toBe(true);
+    });
+
+    it("should return true if operatingSystemFamily is Linux", () => {
+      const props = {
+        runtimePlatform: {
+          operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+        },
+      };
+      expect(isOperatingSystemLinux(props)).toBe(true);
+    });
+
+    it("should return false if operatingSystemFamily is not Linux", () => {
+      const props = {
+        runtimePlatform: {
+          operatingSystemFamily: ecs.OperatingSystemFamily.WINDOWS_SERVER_2019_CORE,
+        },
+      };
+      expect(isOperatingSystemLinux(props)).toBe(false);
+    });
+  });
+
+  describe("getSecretApiKey", () => {
+    it("should return a secret from SecretsManager if apiKeySecret is provided", () => {
+      const secret = secretsmanager.Secret.fromSecretNameV2(scope, "TestSecret", "test-secret");
+      const props = { apiKeySecret: secret };
+      const result = getSecretApiKey(scope, props);
+      expect(result).toBeDefined();
+    });
+
+    it("should return a secret from ARN if apiKeySecretArn is provided", () => {
+      const props = { apiKeySecretArn: "arn:aws:secretsmanager:region:account-id:secret:test-secret" };
+      const result = getSecretApiKey(scope, props);
+      expect(result).toBeDefined();
+    });
+
+    it("should return undefined if no secret is provided", () => {
+      const props = {};
+      const result = getSecretApiKey(scope, props);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("addCdkConstructVersionTag", () => {
+    it("should add a CDK construct version tag to the task", () => {
+      addCdkConstructVersionTag(task);
+      const template = cdk.assertions.Template.fromStack(stack);
+      template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+        Tags: [
+          {
+            Key: "dd_cdk_construct",
+            Value: `v${require("../../version.json").version}`,
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Increase the coverage on the unit tests for the Datadog ECS Fargate construct.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Improving reliability and preventing misconfigurations in user-defined properties.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

N/A

<!--- How did you test this pull request? --->

### Additional Notes

N/A

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
