### PR TITLE
fix: Block CWS configuration on windows

### DIFF
--- a/src/ecs/fargate/utils.ts
+++ b/src/ecs/fargate/utils.ts
@@ -82,6 +82,9 @@ export function validateECSFargateProps(props: DatadogECSFargateInternalProps): 
   }
 
   if (props.cws?.isEnabled) {
+    if (props.isLinux === false) {
+      throw new Error("CWS is only supported on Linux.");
+    }
     if (props.isDatadogDependencyEnabled === false) {
       throw new Error(
         "CWS configuration highly recommends Datadog Agent dependency enabled. The CWS tracer eventually exits the application if it can't connect to the Datadog Agent.",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Prevents customers from enabling CWS on windows hosts.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

The CWS Fargate solution requires `SYS_PTRACE` linux capabilities. This doesn't exist on Windows. Thus, this causes errors when trying to deploy a task on windows with containers requesting permissions that don't exist.

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

N/A

<!--- How did you test this pull request? --->

### Additional Notes

N/A

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
