### PR TITLE
chore: Track agent install info [CONTP-776]

### DIFF
--- a/src/ecs/fargate/environment.ts
+++ b/src/ecs/fargate/environment.ts
@@ -18,9 +18,9 @@ export class FargateEnvVarManager extends EnvVarManager {
 
     this.addAll(props.environmentVariables);
 
-    this.add("DD_INSTALL_INFO_TOOL", "datadog-cdk-constructs");
-    this.add("DD_INSTALL_INFO_TOOL_VERSION", versionJson.version);
-    this.add("DD_INSTALL_INFO_INSTALLER_VERSION", "");
+    this.add("DD_INSTALL_INFO_TOOL", "cdk");
+    this.add("DD_INSTALL_INFO_TOOL_VERSION", "datadog-cdk-constructs");
+    this.add("DD_INSTALL_INFO_INSTALLER_VERSION", versionJson.version);
 
     this.add("DD_API_KEY", props.apiKey);
     this.add("DD_SITE", props.site);

--- a/src/ecs/fargate/environment.ts
+++ b/src/ecs/fargate/environment.ts
@@ -9,6 +9,7 @@
 import log from "loglevel";
 import { FargateDefaultEnvVars } from "./constants";
 import { DatadogECSFargateProps } from "./interfaces";
+import * as versionJson from "../../../version.json";
 import { EnvVarManager } from "../environment";
 
 export class FargateEnvVarManager extends EnvVarManager {
@@ -16,6 +17,10 @@ export class FargateEnvVarManager extends EnvVarManager {
     super(FargateDefaultEnvVars);
 
     this.addAll(props.environmentVariables);
+
+    this.add("DD_INSTALL_INFO_TOOL", "datadog-cdk-constructs");
+    this.add("DD_INSTALL_INFO_TOOL_VERSION", versionJson.version);
+    this.add("DD_INSTALL_INFO_INSTALLER_VERSION", "");
 
     this.add("DD_API_KEY", props.apiKey);
     this.add("DD_SITE", props.site);


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Updates the Agent install tool information to accurately reflect the CDK construct and version.

### Motivation

<!--- What inspired you to submit this pull request? --->

Previously, the install info would default to the docker daemon that installs the container. 

### Testing Guidelines

<!--- How did you test this pull request? --->

N/A

### Additional Notes

<!--- Anything else we should know when reviewing? --->

N/A

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
