### PR TITLE
fix the repository_url tag for gitlab.com

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -76,17 +76,17 @@ function getGitData(): { hash: string; gitRepoUrl: string } {
     log.debug(`Failed to add source code integration. Error: ${e}`);
     return { hash: "", gitRepoUrl: "" };
   }
-  return { hash, gitRepoUrl: filterAndFormatGithubRemote(gitRepoUrl) };
+  return { hash, gitRepoUrl: filterAndFormatGitRemote(gitRepoUrl) };
 }
 
 // Removes sensitive info from the given git remote url and normalizes the url prefix.
 // "git@github.com:" and "https://github.com/" prefixes will be normalized into "github.com/"
-function filterAndFormatGithubRemote(rawRemote: string): string {
+function filterAndFormatGitRemote(rawRemote: string): string {
   rawRemote = filterSensitiveInfoFromRepository(rawRemote);
   if (!rawRemote) {
     return rawRemote;
   }
-  rawRemote = rawRemote.replace(/git@github\.com:|https:\/\/github\.com\//, "github.com/");
+  rawRemote = rawRemote.replace(/git@(github\.com|gitlab\.com):|https:\/\/(github\.com|gitlab\.com)\//, "$1$2/");
 
   return rawRemote;
 }


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

The `git.repository_url` tag can not contain any protocols. For Github, this is being handled already but not for Gitlab (Saas). This PR applies the same normalisation for `gitlab.com`.

### Motivation

<!--- What inspired you to submit this pull request? --->

Received the following error message: 
![Screenshot 2025-05-05 at 15 17 03](https://github.com/user-attachments/assets/9783b445-64dc-42a1-a25b-bd89308452cb)

Noticed that the `repository_url` tag is being set to `https` and realized that it is setting the full URL (including the protocol) in the `DD_TAGS` variable of the Lambda function. 

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
