### PR TITLE
fix(DatadogECSFargate): use correct UST docker labels

### DIFF
--- a/src/ecs/fargate/datadog-ecs-fargate.ts
+++ b/src/ecs/fargate/datadog-ecs-fargate.ts
@@ -221,15 +221,15 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
     // Universal Service Tagging configuration:
     if (this.datadogProps.env) {
       container.addEnvironment("DD_ENV", this.datadogProps.env);
-      container.addDockerLabel("tags.datadoghq.com/env", this.datadogProps.env);
+      container.addDockerLabel("com.datadoghq.tags.env", this.datadogProps.env);
     }
     if (this.datadogProps.service) {
       container.addEnvironment("DD_SERVICE", this.datadogProps.service);
-      container.addDockerLabel("tags.datadoghq.com/service", this.datadogProps.service);
+      container.addDockerLabel("com.datadoghq.tags.service", this.datadogProps.service);
     }
     if (this.datadogProps.version) {
       container.addEnvironment("DD_VERSION", this.datadogProps.version);
-      container.addDockerLabel("tags.datadoghq.com/version", this.datadogProps.version);
+      container.addDockerLabel("com.datadoghq.tags.version", this.datadogProps.version);
     }
   }
 

--- a/test/ecs/fargate/agent.spec.ts
+++ b/test/ecs/fargate/agent.spec.ts
@@ -177,9 +177,9 @@ describe("DatadogECSFargateTaskDefinition", () => {
             }),
           ]),
           DockerLabels: Match.objectLike({
-            "tags.datadoghq.com/env": "test-env",
-            "tags.datadoghq.com/service": "test-service",
-            "tags.datadoghq.com/version": "test-version",
+            "com.datadoghq.tags.env": "test-env",
+            "com.datadoghq.tags.service": "test-service",
+            "com.datadoghq.tags.version": "test-version",
           }),
         }),
       ]),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Fixes #433 
This PR changes the docker labelling in the Fargate ECS construct to align to the Unified Service Tagging [documentation](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging?tab=ecs#configuration-1) 

### Motivation

<!--- What inspired you to submit this pull request? --->
Ensure monitoring features work out of the box as documented.

### Testing Guidelines

<!--- How did you test this pull request? --->
Manually tested the two labelling styles on a personal ECS project to confirm that the documentation was correct and that the labelling style used by the construct does not work.

Updated unit test to expect corrected label names.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
