### PR TITLE
feat: Use GitHub App for upgrade workflow

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -45,6 +45,12 @@ jobs:
       contents: read
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout
         uses: actions/checkout@v4
       - name: Download patch
@@ -62,7 +68,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           commit-message: |-
             chore(deps): upgrade dependencies
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const { awscdk, javascript } = require("projen");
+const { awscdk, javascript, github } = require("projen");
 
 const project = new awscdk.AwsCdkConstructLibrary({
   name: "datadog-cdk-constructs-v2",
@@ -82,6 +82,10 @@ const project = new awscdk.AwsCdkConstructLibrary({
   depsUpgradeOptions: {
     workflowOptions: {
       schedule: javascript.UpgradeDependenciesSchedule.WEEKLY,
+      projenCredentials: github.GithubCredentials.fromApp({
+        appIdSecret: "GH_APP_ID",
+        privateKeySecret: "GH_APP_PRIVATE_KEY",
+      }),
     },
   },
 });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Makes the upgrade workflow use GitHub Apps to get temporary tokens instead of using long-lived PATs.

### Motivation

<!--- What inspired you to submit this pull request? --->

GitHub App is more secure than PAT.

### Testing Guidelines

<!--- How did you test this pull request? --->

Will run `upgrade` workflow after the workflow is fixed in https://github.com/DataDog/datadog-cdk-constructs/pull/420. It's broken right now.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

Before this PR, I opened a ticket to request this GitHub app.
- Ticket form: https://datadoghq.atlassian.net/jira/software/c/projects/GHGOV/forms/form/direct/1213960947439456/10002
- Ticket: https://datadoghq.atlassian.net/browse/GHGOV-22

@zihaoyu shared to me:
- app id
- installation id
- private key

And I added these repo secrets:
- `GH_APP_ID`
- `GH_APP_PRIVATE_KEY`

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
