### PR TITLE
chore: Use a protected env for upgrade workflow

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -92,3 +92,5 @@ jobs:
           author: github-actions <github-actions@github.com>
           committer: github-actions <github-actions@github.com>
           signoff: true
+    environment:
+      name: protected-main-env

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,5 +1,5 @@
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const { awscdk, javascript, github } = require("projen");
+const { awscdk, javascript, github, JsonPatch } = require("projen");
 
 const project = new awscdk.AwsCdkConstructLibrary({
   name: "datadog-cdk-constructs-v2",
@@ -89,6 +89,14 @@ const project = new awscdk.AwsCdkConstructLibrary({
     },
   },
 });
+
+// Use a protected environment for the upgrade workflow to access the environment secrets
+project.github?.tryFindWorkflow("upgrade")?.file?.patch(
+  JsonPatch.add("/jobs/pr/environment", {
+    name: "protected-main-env",
+  }),
+);
+
 const eslintConfig = project.tryFindObjectFile(".eslintrc.json");
 eslintConfig.addOverride("extends", [
   "plugin:@typescript-eslint/recommended",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Make the dependency upgrade workflow `upgrade.yml` use an environment `protected-main-env`.

### Motivation

<!--- What inspired you to submit this pull request? --->

Right now the secrets for the GitHub App (`GH_APP_ID` and `GH_APP_PRIVATE_KEY`) are repo secrets, which can be made more secure by changing to environment secrets following this guide: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3034155880/Guide+How+to+Secure+Your+GitHub+Repositories#Secret-management

Before this PR, I just created an environment `protected-main-env` that has the two secrets. After this PR is merged, I will remove the two repo secrets.

### Testing Guidelines

<!--- How did you test this pull request? --->

To test after merging this PR because the workflow can only run on main. 

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog

Jira: https://datadoghq.atlassian.net/browse/SVLS-6927