### PR TITLE
chore: Make permissions explicit in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Generate token

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -101,6 +101,10 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   }),
 );
 
+project.github
+  ?.tryFindWorkflow("upgrade")
+  ?.file?.patch(JsonPatch.add("/jobs/pr/permissions/pull-requests", github.workflows.JobPermission.WRITE));
+
 const eslintConfig = project.tryFindObjectFile(".eslintrc.json");
 eslintConfig.addOverride("extends", [
   "plugin:@typescript-eslint/recommended",


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Explicitly add
```
    permissions:
      pull-requests: write
```
to the `pr` step of the `upgrade` workflow.

### Motivation

<!--- What inspired you to submit this pull request? --->

Although the workflow can run successfully without this, it's good to make it explicit as @zihaoyu recommended in https://datadoghq.atlassian.net/browse/GHGOV-22.

### Testing Guidelines

<!--- How did you test this pull request? --->

Not testable now because there's no update yet. Will test in production in the future.

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
