### PR TITLE
chore: Automate cdk upgrade

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 18.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
+      - name: Upgrade CDK versions
+        run: node scripts/upgrade-cdk.js
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ jspm_packages/
 !src/sample
 !src/sample/lambda_nodejs/hello_node.js
 !scripts/fix-version.js
+!scripts/upgrade-cdk.js
 *.d.ts
 .cdk.staging
 cdk.out/

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.208.0",
+      "version": "^2.204.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -25,8 +25,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
     packageName: "ddcdkconstruct",
   },
   peerDeps: [],
-  cdkVersion: "2.208.0",
-  cdkCliVersion: "^2.208.0",
+  cdkVersion: "2.204.0",
+  cdkCliVersion: "^2.204.0",
   deps: ["loglevel"],
   bundledDeps: ["loglevel"],
   devDeps: [
@@ -44,6 +44,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "!src/sample",
     "!src/sample/lambda_nodejs/hello_node.js",
     "!scripts/fix-version.js",
+    "!scripts/upgrade-cdk.js",
     "*.d.ts",
     ".cdk.staging",
     "cdk.out/",
@@ -99,6 +100,17 @@ const project = new awscdk.AwsCdkConstructLibrary({
 project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   JsonPatch.add("/jobs/pr/environment", {
     name: "protected-main-env",
+  }),
+);
+
+// Patch the upgrade workflow since its managed by projen
+// to add a step to upgrade the CDK versions.  3 happens to
+// be the index after install dependencies and before the
+// other dependency upgrade step.
+project.github?.tryFindWorkflow("upgrade")?.file?.patch(
+  JsonPatch.add("/jobs/upgrade/steps/3", {
+    name: "Upgrade CDK versions",
+    run: "node scripts/upgrade-cdk.js",
   }),
 );
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.208.0",
+    "aws-cdk-lib": "2.204.0",
     "constructs": "10.0.5",
     "esbuild": "^0.25.8",
     "eslint": "^9",
@@ -59,7 +59,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.208.0",
+    "aws-cdk-lib": "^2.204.0",
     "constructs": "^10.0.5"
   },
   "dependencies": {

--- a/scripts/upgrade-cdk.js
+++ b/scripts/upgrade-cdk.js
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const cdkVersionRegex =  /cdkVersion:\s*"([~^]?\d+\.\d+\.\d+)"/
+const cdkCliVersionRegex = /cdkCliVersion:\s*"([~^]?\d+\.\d+\.\d+)"/
+
+const cdkVersion = cdkVersionRegex.exec(fs.readFileSync(".projenrc.js", "utf8"))[1];
+const cdkCliVersion = cdkCliVersionRegex.exec(fs.readFileSync(".projenrc.js", "utf8"))[1];
+
+console.log(`cdkVersion: "${cdkVersion}"`);
+console.log(`cdkCliVersion: "${cdkCliVersion}"`);
+
+const tagsWithDates = JSON.parse(execSync("npm view aws-cdk-lib time --json", { encoding: "utf8" }).trim());
+
+const targetTime = new Date();
+targetTime.setMonth(targetTime.getMonth() - 1);
+
+let targetVersion = null;
+let closestTimeDiff = Infinity;
+
+for (const [version, dateStr] of Object.entries(tagsWithDates)) {
+  // Skip non-version entries like 'created', 'modified'
+  if (version === 'created' || version === 'modified') continue;
+  
+  const versionDate = new Date(dateStr);
+  
+  const timeDiff = Math.abs(targetTime.getTime() - versionDate.getTime());
+  if (timeDiff < closestTimeDiff) {
+    closestTimeDiff = timeDiff;
+    targetVersion = version;
+  }
+}
+
+console.log(`Target date (1 month ago): ${targetTime.toISOString().split('T')[0]}`);
+console.log(`aws-cdk-lib version from ~1 month ago: "${targetVersion}"`);
+
+if (cdkVersion !== targetVersion || cdkCliVersion !== targetVersion) {
+  console.log("Upgrading CDK versions...");
+  
+  // Read the entire .projenrc.js file
+  let projenContent = fs.readFileSync(".projenrc.js", "utf8");
+  
+  // Update cdkVersion if it's different from latest
+  if (cdkVersion !== targetVersion) {
+    projenContent = projenContent.replace(
+      cdkVersionRegex,
+      `cdkVersion: "${targetVersion}"`
+    );
+    console.log(`Updated cdkVersion to: "${targetVersion}"`);
+  }
+  
+  // Update cdkCliVersion if it's different from latest
+  if (cdkCliVersion !== targetVersion) {
+    projenContent = projenContent.replace(
+      cdkCliVersionRegex,
+      `cdkCliVersion: "^${targetVersion}"`
+    );
+    console.log(`Updated cdkCliVersion to: "${targetVersion}"`);
+  }
+  
+  // Write the updated content back to the file
+  fs.writeFileSync(".projenrc.js", projenContent);
+  console.log("CDK versions upgraded successfully!");
+} else {
+  console.log("CDK versions are already up to date.");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda-python-alpha/-/aws-lambda-python-alpha-2.134.0-alpha.0.tgz#8a85a8f08a05f71f6fca55d14da6cb3116c3612d"
   integrity sha512-St+Ej+Efm1+EPz5k1D+4ej8zod+1/ocK7hBsSPFI2hfnEfBPQci9Pkjr8qkNnU8ODB3ZJpL08r/ghi4XMTf0PQ==
 
-"@aws-cdk/cloud-assembly-schema@^45.2.0":
+"@aws-cdk/cloud-assembly-schema@^45.0.0":
   version "45.2.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-45.2.0.tgz#bd4bf1e16189a2d424b9ab503db48ca9732325b1"
   integrity sha512-5TTUkGHQ+nfuUGwKA8/Yraxb+JdNUh4np24qk/VHXmrCMq+M6HfmGWfhcg/QlHA2S5P3YIamfYHdQAB4uSNLAg==
@@ -1359,14 +1359,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.208.0:
-  version "2.208.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.208.0.tgz#bec8ae4219b857b75d2841e4c6f023c42bdedd10"
-  integrity sha512-lZW475enKz36A/hZvS7xUwfjeqLqxKgBmZ2cGA7BB5PAlQsjBfN70ZGDgGl0egug5fb/hsYy1Dy4OrclfNzxFg==
+aws-cdk-lib@2.204.0:
+  version "2.204.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.204.0.tgz#312240c4f21d3fb7a42d420890afe2563e4fad74"
+  integrity sha512-mY3nYu+QvPhO+fz+LCFKbc0PFhTHbHzDLnbcA2fPcQBKciYnTixpBd2ccRlKYWbG4y6NTc6ju6DudZ3HIS4OlA==
   dependencies:
     "@aws-cdk/asset-awscli-v1" "2.2.242"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.1.0"
-    "@aws-cdk/cloud-assembly-schema" "^45.2.0"
+    "@aws-cdk/cloud-assembly-schema" "^45.0.0"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.3.0"


### PR DESCRIPTION
### What does this PR do?
Automate the cdk upgrade flow.  To do this I created a script to parsed the cdk version out of the projen rc file, then check the npm version from 1 month ago.  I chose that because that's the minimum version that someone needs, so 1 month behind seemed like a middle ground between being recent enough and not having someone have to go back and forth between upgrading the datadog cdk constructs and cdk versions, if they're doing some kind of weekly upgrade like we usually have.  Let me know if you prefer a different value for this.

The script has to be included in the github upgrade workflow, so we have to overwrite it in projen since its managed for us.

Projen docs about this: https://projen.io/docs/project-types/aws-cdk-construct-library/#depending-on-aws-cdk-lib

### Motivation

The CDK version is getting out of date, we're about 7 months behind: Issues: https://github.com/DataDog/datadog-cdk-constructs/issues/465

### Testing Guidelines

I tested this locally and it seems to work, I'll run it manually once this is merged to know for sure.


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
