### PR TITLE
chore: Allow unit tests to run in gitlab

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -174,7 +174,7 @@
           "exec": "rm -fr lib/"
         },
         {
-          "exec": "jest --passWithNoTests --all"
+          "exec": "jest --runInBand --verbose --passWithNoTests --all"
         },
         {
           "spawn": "eslint"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -191,7 +191,7 @@ projenTasks.addOverride("tasks.test.steps", [
     exec: "rm -fr lib/",
   },
   {
-    exec: "jest --passWithNoTests --all",
+    exec: "jest --runInBand --verbose --passWithNoTests --all",
   },
   {
     spawn: "eslint",

--- a/examples/ecs/typescript-stack/package.json
+++ b/examples/ecs/typescript-stack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-stack",
+  "name": "typescript-ecs-stack",
   "version": "1.0.0",
   "bin": {
     "cdk-typescript": "bin/index.js"

--- a/examples/step-functions-typescript-stack/package.json
+++ b/examples/step-functions-typescript-stack/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-stack",
+  "name": "typescript-step-functions-stack",
   "version": "1.0.0",
   "bin": {
     "cdk-typescript": "bin/index.js"

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -14,6 +14,7 @@ const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
 const CUSTOM_EXTENSION_LAYER_ARN = "arn:aws:lambda:us-east-1:123456789:layer:Datadog-Extension-custom:1";
 const NODE_LAYER_VERSION = 91;
+const REPO_REGEX = /git\.repository_url:.*\/DataDog\/datadog-cdk-constructs(\.git)?/;
 
 describe("validateProps", () => {
   it("throws an error when the site is set to an invalid site URL", () => {
@@ -878,10 +879,7 @@ describe("overrideGitMetadata", () => {
 
     [hello, goodbye].forEach((f) => {
       expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining("git.commit.sha:fake-sha"),
-          expect.stringContaining("git.repository_url:github.com/DataDog/datadog-cdk-constructs"),
-        ]),
+        expect.arrayContaining([expect.stringContaining("git.commit.sha:fake-sha"), expect.stringMatching(REPO_REGEX)]),
       );
     });
   });
@@ -908,7 +906,7 @@ describe("overrideGitMetadata", () => {
       (<any>hello).environment[DD_TAGS].value.split(",").some((item: string) => item.includes("git.commit.sha")),
     ).toEqual(true);
     expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
-      expect.arrayContaining([expect.stringContaining("git.repository_url:github.com/DataDog/datadog-cdk-constructs")]),
+      expect.arrayContaining([expect.stringMatching(REPO_REGEX)]),
     );
   });
 


### PR DESCRIPTION
### What does this PR do?

Allow the unit tests to work in gitlab.  There is something about our tests that is probably getting re used when we may not intend to, or something that isn't getting reset properly.  This was making the tests hang in gitlab, I'm not sure why but for now lets set run in band to make it run sequentially. This takes longer but is consistent.

Also change the github URL to match either the github or the gitlab url, with the .git at the end being optional.

Modify the names of the example stacks os that they don't overlap as well, this was giving us a warning.

### Motivation

Moving release to gitlab
* JIRA: https://datadoghq.atlassian.net/browse/SVLS-7287

### Testing Guidelines

* Passing gitlab job: https://gitlab.ddbuild.io/DataDog/datadog-cdk-constructs/-/jobs/1079139184
* Github / Gitlab issue: https://gitlab.ddbuild.io/DataDog/datadog-cdk-constructs/-/jobs/1079119360#L317
* Hanging gitlab job: https://gitlab.ddbuild.io/DataDog/datadog-cdk-constructs/-/jobs/1079015266

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
