### PR TITLE
chore: Add version.json update to create release script

### DIFF
--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -21,9 +21,15 @@ if [ $MATCHING_GITHUB_VERSION ]; then
     exit 1
 fi
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+VERSION_FILE="$SCRIPT_DIR/../version.json"
+jq --arg v "$RELEASE_VERSION" '.version = $v' "$VERSION_FILE" > "$VERSION_FILE.tmp" && mv "$VERSION_FILE.tmp" "$VERSION_FILE"
+
+git add $VERSION_FILE
+
 # Create a commit with all of the commit info for commits in this release
 INCLUDED_COMMITS=$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline)
-git commit -m "Release v2-$RELEASE_VERSION
+git commit -m "chore: Release v2-$RELEASE_VERSION
 
 This release includes the following commits:
 $(echo "$INCLUDED_COMMITS")


### PR DESCRIPTION
### What does this PR do?
Add a line to update the version.json file in the create_release script. This is needed both to keep it up to date, and to allow us to use a non empty PR to approve releases.

Also add chore: to the prefix of the commit so it gets added to the PR title to keep the PR title linter happy.

### Motivation

Updating release process

### Testing Guidelines

Updated script used for this release commit - https://github.com/DataDog/datadog-cdk-constructs/pull/474

### Additional Notes

JIRA: https://datadoghq.atlassian.net/browse/SVLS-7287

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
