### PR TITLE
feat(CONTP-922): Expose ability to provide custom ecs.FireLenseLogDriver upon log driver creation

### DIFF
--- a/src/ecs/fargate/README.md
+++ b/src/ecs/fargate/README.md
@@ -212,17 +212,18 @@ For more general information, reference the [Datadog ECS Fargate Docs](https://d
 
 ### FluentbitConfig
 
-| Property                       | Type                       | Description                                                                      |
-| ------------------------------ | -------------------------- | -------------------------------------------------------------------------------- |
-| `logDriverConfig`              | `DatadogECSLogDriverProps` | The configuration for the Datadog fluentbit log driver.                          |
-| `firelensOptions`              | `DatadogFirelensOptions`   | The Firelens configuration on the fluentbit container.                           |
-| `isLogRouterEssential`         | `boolean`                  | Makes the log router essential.                                                  |
-| `isLogRouterDependencyEnabled` | `boolean`                  | Enables the log router health check.                                             |
-| `logRouterHealthCheck`         | `HealthCheck`              | Health check configuration for the log router.                                   |
-| `cpu`                          | `number`                   | The minimum number of CPU units to reserve for the Datadog fluent-bit container. |
-| `memoryLimitMiB`               | `number`                   | The amount (in MiB) of memory to present to the Datadog fluent-bit container.    |
-| `registry`                     | `string`                   | The registry to pull the Fluentbit container image from.                         |
-| `imageVersion`                 | `string`                   | The version of the Fluentbit container image to use.                             |
+| Property                       | Type                       | Description                                                                            |
+| ------------------------------ | -------------------------- |----------------------------------------------------------------------------------------|
+| `logDriverConfig`              | `DatadogECSLogDriverProps` | The configuration for the Datadog fluentbit log driver.                                |
+| `firelensLogDriver`            | `FireLensLogDriver`        | A supplied log driver that is used instead of creating one with the log driver config. |
+| `firelensOptions`              | `DatadogFirelensOptions`   | The Firelens configuration on the fluentbit container.                                 |
+| `isLogRouterEssential`         | `boolean`                  | Makes the log router essential.                                                        |
+| `isLogRouterDependencyEnabled` | `boolean`                  | Enables the log router health check.                                                   |
+| `logRouterHealthCheck`         | `HealthCheck`              | Health check configuration for the log router.                                         |
+| `cpu`                          | `number`                   | The minimum number of CPU units to reserve for the Datadog fluent-bit container.       |
+| `memoryLimitMiB`               | `number`                   | The amount (in MiB) of memory to present to the Datadog fluent-bit container.          |
+| `registry`                     | `string`                   | The registry to pull the Fluentbit container image from.                               |
+| `imageVersion`                 | `string`                   | The version of the Fluentbit container image to use.                                   |
 
 ### DatadogFirelensOptions
 

--- a/src/ecs/fargate/README.md
+++ b/src/ecs/fargate/README.md
@@ -213,7 +213,7 @@ For more general information, reference the [Datadog ECS Fargate Docs](https://d
 ### FluentbitConfig
 
 | Property                       | Type                       | Description                                                                            |
-| ------------------------------ | -------------------------- |----------------------------------------------------------------------------------------|
+| ------------------------------ | -------------------------- | -------------------------------------------------------------------------------------- |
 | `logDriverConfig`              | `DatadogECSLogDriverProps` | The configuration for the Datadog fluentbit log driver.                                |
 | `firelensLogDriver`            | `FireLensLogDriver`        | A supplied log driver that is used instead of creating one with the log driver config. |
 | `firelensOptions`              | `DatadogFirelensOptions`   | The Firelens configuration on the fluentbit container.                                 |

--- a/src/ecs/fargate/datadog-ecs-fargate.ts
+++ b/src/ecs/fargate/datadog-ecs-fargate.ts
@@ -301,8 +301,8 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
     }
 
     const fluentbitConfig = this.datadogProps.logCollection!.fluentbitConfig!;
-    if (fluentbitConfig.firelensLogDriver) {
-      return fluentbitConfig.firelensLogDriver;
+    if (fluentbitConfig.fireLensLogDriver) {
+      return fluentbitConfig.fireLensLogDriver;
     }
 
     // Otherwise, create a FireLenseLogDriver using the provided config

--- a/src/ecs/fargate/datadog-ecs-fargate.ts
+++ b/src/ecs/fargate/datadog-ecs-fargate.ts
@@ -301,8 +301,8 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
     }
 
     const fluentbitConfig = this.datadogProps.logCollection!.fluentbitConfig!;
-    if (fluentbitConfig.fireLensLogDriver) {
-      return fluentbitConfig.fireLensLogDriver;
+    if (fluentbitConfig.firelensLogDriver) {
+      return fluentbitConfig.firelensLogDriver;
     }
 
     // Otherwise, create a FireLenseLogDriver using the provided config

--- a/src/ecs/fargate/interfaces.ts
+++ b/src/ecs/fargate/interfaces.ts
@@ -6,7 +6,7 @@
  * Copyright 2021 Datadog, Inc.
  */
 
-import { HealthCheck, FirelensOptions } from "aws-cdk-lib/aws-ecs";
+import { HealthCheck, FirelensOptions, FireLensLogDriver } from "aws-cdk-lib/aws-ecs";
 import { CWSFeatureConfig, DatadogECSBaseProps, LogCollectionFeatureConfig } from "../interfaces";
 
 export interface DatadogECSFargateProps extends DatadogECSBaseProps {
@@ -43,6 +43,10 @@ export interface FluentbitConfig {
    * Configuration for the Datadog log driver.
    */
   readonly logDriverConfig?: DatadogECSLogDriverProps;
+  /**
+   * Supply own FireLensLogDriver. Either this or logDriverConfig can be provided but not both.
+   */
+  readonly firelensLogDriver?: FireLensLogDriver;
   /**
    * Firelens options for the Fluentbit container.
    */

--- a/src/ecs/fargate/interfaces.ts
+++ b/src/ecs/fargate/interfaces.ts
@@ -46,7 +46,7 @@ export interface FluentbitConfig {
   /**
    * Supply own FireLensLogDriver. Either this or logDriverConfig can be provided but not both.
    */
-  readonly fireLensLogDriver?: FireLensLogDriver;
+  readonly firelensLogDriver?: FireLensLogDriver;
   /**
    * Firelens options for the Fluentbit container.
    */

--- a/src/ecs/fargate/interfaces.ts
+++ b/src/ecs/fargate/interfaces.ts
@@ -46,7 +46,7 @@ export interface FluentbitConfig {
   /**
    * Supply own FireLensLogDriver. Either this or logDriverConfig can be provided but not both.
    */
-  readonly firelensLogDriver?: FireLensLogDriver;
+  readonly fireLensLogDriver?: FireLensLogDriver;
   /**
    * Firelens options for the Fluentbit container.
    */

--- a/test/ecs/fargate/logging.spec.ts
+++ b/test/ecs/fargate/logging.spec.ts
@@ -292,7 +292,7 @@ describe("DatadogECSFargateLogging", () => {
       logCollection: {
         isEnabled: true,
         fluentbitConfig: {
-          fireLensLogDriver: new ecs.FireLensLogDriver({
+          firelensLogDriver: new ecs.FireLensLogDriver({
             options: {
               Name: "custom-firelens",
               provider: "ecs",
@@ -331,7 +331,7 @@ describe("DatadogECSFargateLogging", () => {
       logCollection: {
         isEnabled: true,
         fluentbitConfig: {
-          fireLensLogDriver: new ecs.FireLensLogDriver({
+          firelensLogDriver: new ecs.FireLensLogDriver({
             options: {
               Name: "custom-firelens",
               provider: "ecs",

--- a/test/ecs/fargate/logging.spec.ts
+++ b/test/ecs/fargate/logging.spec.ts
@@ -285,4 +285,86 @@ describe("DatadogECSFargateLogging", () => {
       ]),
     });
   });
+
+  it("configures log driver using provided FireLensLogDriver", () => {
+    datadogProps = {
+      ...datadogProps,
+      logCollection: {
+        isEnabled: true,
+        fluentbitConfig: {
+          fireLensLogDriver: new ecs.FireLensLogDriver({
+            options: {
+              Name: "custom-firelens",
+              provider: "ecs",
+              TLS: "on",
+              Host: "http-intake.logs.datadoghq.com-test",
+            },
+          }),
+        },
+      },
+    };
+
+    const task = new ecsDatadog.DatadogECSFargateTaskDefinition(scope, id, props, datadogProps);
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Image: task.datadogContainer.imageName,
+          LogConfiguration: {
+            LogDriver: "awsfirelens",
+            Options: Match.objectLike({
+              Name: "custom-firelens",
+              Host: "http-intake.logs.datadoghq.com-test",
+              TLS: "on",
+              provider: "ecs",
+            }),
+          },
+        }),
+      ]),
+    });
+  });
+
+  it("configures log driver with provided FireLensLogDriver even if logDriverConfig is set", () => {
+    datadogProps = {
+      ...datadogProps,
+      logCollection: {
+        isEnabled: true,
+        fluentbitConfig: {
+          fireLensLogDriver: new ecs.FireLensLogDriver({
+            options: {
+              Name: "custom-firelens",
+              provider: "ecs",
+              TLS: "on",
+              Host: "http-intake.logs.datadoghq.com-test",
+            },
+          }),
+          logDriverConfig: {
+            tls: "off",
+            hostEndpoint: "http-intake.logs.datadoghq.com",
+          },
+        },
+      },
+    };
+
+    const task = new ecsDatadog.DatadogECSFargateTaskDefinition(scope, id, props, datadogProps);
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: Match.arrayWith([
+        Match.objectLike({
+          Image: task.datadogContainer.imageName,
+          LogConfiguration: {
+            LogDriver: "awsfirelens",
+            Options: Match.objectLike({
+              Name: "custom-firelens",
+              Host: "http-intake.logs.datadoghq.com-test",
+              TLS: "on",
+              provider: "ecs",
+            }),
+          },
+        }),
+      ]),
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Adds a `fireLensLogDriver: FireLensLogDriver` field to `FluentbitConfig` which is used as the log driver in-place of creating our own driver with the `logDriverConfig`.

### Motivation

Customer request #465 asking for `ecs.FireLensLogDriver` to be an exposed option in the dd cdk construct.

### Testing Guidelines

1. Unit tests added in `logging.spec.ts` and CI is 🟢 
2. Manually QA'd to confirm user configured `fireLensLogDriver` is used on creation.

<img width="908" height="727" alt="Screenshot 2025-09-18 at 10 52 59 AM" src="https://github.com/user-attachments/assets/349122a5-8344-4502-a8c3-5de0273ca48b" />


### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] New feature

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [x] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
