### PR TITLE
chore: Update unsupported node version test to not call determineLatestNodeRuntime

### DIFF
--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -1,4 +1,4 @@
-import { App, Stack, Token } from "aws-cdk-lib";
+import { App, Fn, Stack, Token } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { LogGroup } from "aws-cdk-lib/aws-logs";
@@ -660,7 +660,10 @@ describe("addLambdaFunctions", () => {
     const stack = new Stack(app, "stack");
     const hello = new lambda.Function(stack, "HelloHandler", {
       // unresolved Node runtime. Its name is like '${Token[TOKEN.330]}'.
-      runtime: lambda.Runtime.NODEJS_10_X,
+      runtime: new lambda.Runtime(Fn.importValue(lambda.Runtime.NODEJS_LATEST.name), lambda.RuntimeFamily.NODEJS, {
+        supportsInlineCode: true,
+        isVariable: true,
+      }),
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

This PR updates our 'unsupported node version' test to use a fixed unsupported value instead of an unresolved value returned by `lambda.determineLatestNodeRuntime()`.

This test was originally added in PR https://github.com/DataDog/datadog-cdk-constructs/pull/348 in response to GitHub issue https://github.com/DataDog/datadog-cdk-constructs/issues/314. 

At that time, `lambda.determineLatestNodeRuntime()` returned an unresolved runtime.

We now have a PR to update dependencies (https://github.com/DataDog/datadog-cdk-constructs/pull/481/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) including bumping to `2.213.0` of `aws-cdk-lib`. In the newer version of `aws-cdk-lib`, `lambda.determineLatestNodeRuntime()` resolves to Node 22, so this test now fails. 

This PR updates the test so that we can proceed with the dependency upgrade.

### Motivation

<!--- What inspired you to submit this pull request? --->

Unblock upgrade dependencies PR https://github.com/DataDog/datadog-cdk-constructs/pull/481/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519.

### Testing Guidelines

<!--- How did you test this pull request? --->
- On https://github.com/DataDog/datadog-cdk-constructs/pull/481/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519, ran `yarn build`, saw it fail
- Made this change on top of https://github.com/DataDog/datadog-cdk-constructs/pull/481/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519
- Ran ``yarn build` again, it passes

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
