### PR TITLE
chore: Add example of passing in props to ECS Fargate task definition

### DIFF
--- a/examples/ecs/python-stack/cdk_python/cdk_python_stack.py
+++ b/examples/ecs/python-stack/cdk_python/cdk_python_stack.py
@@ -17,7 +17,14 @@ class CdkPythonStack(Stack):
             global_tags="owner:datadog, team:contp",
         )
 
-        task = ecsDatadog.fargate_task_definition(self, "PythonFargateTask")
+        task = ecsDatadog.fargate_task_definition(
+            self,
+            "PythonFargateTask",
+            props=ecs.FargateTaskDefinitionProps(
+                memory_limit_mib=512,
+                family="task-def-family",
+            ),
+        )
 
         task.add_container(
             id = "dogstatsd-app",


### PR DESCRIPTION



<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Add an example of passing the props into the fargate task definition function.  The props won't be automatically converted if they are just passed in as a dictionary, as found in the linked issue.


### Motivation

Github issue: https://github.com/DataDog/datadog-cdk-constructs/issues/479?reload=1?reload=1


### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
