### PR TITLE
feat(env): always add DD_ env vars

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -174,19 +174,17 @@ export function applyEnvVariables(lam: lambda.Function, baseProps: DatadogLambda
 }
 
 export function setDDEnvVariables(lam: lambda.Function, props: DatadogLambdaProps): void {
-  if (props.extensionLayerVersion || props.extensionLayerArn) {
-    if (props.env) {
-      lam.addEnvironment(DD_ENV_ENV_VAR, props.env);
-    }
-    if (props.service) {
-      lam.addEnvironment(DD_SERVICE_ENV_VAR, props.service);
-    }
-    if (props.version) {
-      lam.addEnvironment(DD_VERSION_ENV_VAR, props.version);
-    }
-    if (props.tags) {
-      lam.addEnvironment(DD_TAGS, props.tags);
-    }
+  if (props.env) {
+    lam.addEnvironment(DD_ENV_ENV_VAR, props.env);
+  }
+  if (props.service) {
+    lam.addEnvironment(DD_SERVICE_ENV_VAR, props.service);
+  }
+  if (props.version) {
+    lam.addEnvironment(DD_VERSION_ENV_VAR, props.version);
+  }
+  if (props.tags) {
+    lam.addEnvironment(DD_TAGS, props.tags);
   }
   if (props.enableColdStartTracing !== undefined) {
     lam.addEnvironment(DD_COLD_START_TRACING, props.enableColdStartTracing.toString().toLowerCase());


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Always adds datadog env vars, even when the extension version isn't specified as some folks may be using a dockerized lambda and may still want them.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

Implements a fix for https://github.com/DataDog/datadog-cdk-constructs/issues/320

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

Unit tests

### Additional Notes

This shouldn't have any impact on existing users as adding the env vars shouldn't cause any problems.

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog