### PR TITLE
chore: update CI to node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node 18
+      - name: Set up Node 24
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Cache Node modules
         id: cache-node-modules

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node 18
+      - name: Set up Node 24
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Cache Node modules
         id: cache-node-modules


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Updates node in CI to 24 LTS, since node 18 has been EOL since april of this year.

<!--- A brief description of the change being made with this pull request. --->

### Motivation

[Warning logs in CI](https://github.com/DataDog/datadog-cdk-constructs/actions/runs/19586672420/job/56096893801?pr=502)

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

CI

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog