### PR TITLE
fix: [SVLS-8077] Only set AWS_LAMBDA_EXEC_WRAPPER if extension is configured

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -124,7 +124,8 @@ export class DatadogLambda extends Construct {
         }
       }
 
-      if (baseProps.extensionLayerVersion !== undefined || baseProps.extensionLayerArn !== undefined) {
+      const useExtension = baseProps.extensionLayerVersion !== undefined || baseProps.extensionLayerArn !== undefined;
+      if (useExtension) {
         const errors = applyExtensionLayer(
           this.scope,
           region,
@@ -135,14 +136,14 @@ export class DatadogLambda extends Construct {
         );
         if (errors.length > 0) {
           log.warn(
-            `Failed to apply extention layer to the Lambda function ${lambdaFunction.functionName}. Skipping instrumenting it.`,
+            `Failed to apply extension layer to the Lambda function ${lambdaFunction.functionName}. Skipping instrumenting it.`,
           );
           continue;
         }
       }
 
       if (baseProps.redirectHandler) {
-        redirectHandlers(lambdaFunction, baseProps.addLayers);
+        redirectHandlers(lambdaFunction, baseProps.addLayers, useExtension);
       }
 
       if (this.props.forwarderArn !== undefined) {

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -27,14 +27,16 @@ import {
  *
  * Unchanged aside from parameter type
  */
-export function redirectHandlers(lam: lambda.Function, addLayers: boolean): void {
+export function redirectHandlers(lam: lambda.Function, addLayers: boolean, useExtension: boolean): void {
   log.debug(`Wrapping Lambda function handlers with Datadog handler...`);
 
   const runtime: string = lam.runtime.name;
   const runtimeType: RuntimeType = runtimeLookup[runtime];
 
   if (runtimeType === RuntimeType.JAVA || runtimeType === RuntimeType.DOTNET) {
-    lam.addEnvironment(AWS_LAMBDA_EXEC_WRAPPER_ENV_VAR, AWS_LAMBDA_EXEC_WRAPPER);
+    if (useExtension) {
+      lam.addEnvironment(AWS_LAMBDA_EXEC_WRAPPER_ENV_VAR, AWS_LAMBDA_EXEC_WRAPPER);
+    }
     return;
   }
 

--- a/test/redirect.spec.ts
+++ b/test/redirect.spec.ts
@@ -24,7 +24,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers(hello, true);
+    redirectHandlers(hello, true, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${JS_HANDLER_WITH_LAYERS}`,
     });
@@ -42,7 +42,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers(hello, false);
+    redirectHandlers(hello, false, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${JS_HANDLER}`,
     });
@@ -60,7 +60,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromInline("test"),
       handler: "hello.handler",
     });
-    redirectHandlers(hello, true);
+    redirectHandlers(hello, true, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: `${PYTHON_HANDLER}`,
     });
@@ -76,7 +76,7 @@ describe("redirectHandlers", () => {
   it.each([
     ["JAVA", lambda.Runtime.JAVA_21],
     ["DOTNET", lambda.Runtime.DOTNET_8],
-  ])("skips redirecting handler for '%s' and sets wrapper env var", (_text, runtime) => {
+  ])("skips redirecting handler for '%s' and sets wrapper env var when extension configured", (_text, runtime) => {
     const app = new App();
     const stack = new Stack(app, "stack", {
       env: {
@@ -88,7 +88,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
       handler: "handleRequest",
     });
-    redirectHandlers(hello, true);
+    redirectHandlers(hello, true, true);
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: "handleRequest",
     });
@@ -99,6 +99,36 @@ describe("redirectHandlers", () => {
         },
       },
     });
+  });
+
+  it.each([
+    ["JAVA", lambda.Runtime.JAVA_21],
+    ["DOTNET", lambda.Runtime.DOTNET_8],
+  ])("does not set wrapper env var when extension is not configured", (_text, runtime) => {
+    const app = new App();
+    const stack = new Stack(app, "stack", {
+      env: {
+        region: "us-west-2",
+      },
+    });
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: runtime,
+      code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
+      handler: "handleRequest",
+    });
+    redirectHandlers(hello, true, false);
+    Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
+      Handler: "handleRequest",
+    });
+    Template.fromStack(stack).resourcePropertiesCountIs(
+      "AWS::Lambda::Function",
+      {
+        Environment: {
+          Variables: {},
+        },
+      },
+      0,
+    );
   });
 
   it("doesn't set env vars for function with unsupported JAVA version", () => {
@@ -113,7 +143,7 @@ describe("redirectHandlers", () => {
       code: lambda.Code.fromAsset(__dirname + "/../integration_tests/lambda"),
       handler: "handleRequest",
     });
-    redirectHandlers(hello, true);
+    redirectHandlers(hello, true, true);
     Template.fromStack(stack).resourcePropertiesCountIs(
       "AWS::Lambda::Function",
       {
@@ -137,7 +167,7 @@ describe("redirectHandlers", () => {
     const hello = new lambda.DockerImageFunction(stack, "HelloHandler", {
       code: lambda.DockerImageCode.fromImageAsset("./test/assets"),
     });
-    redirectHandlers(hello, true);
+    redirectHandlers(hello, true, true);
 
     Template.fromStack(stack).hasResourceProperties("AWS::Lambda::Function", {
       Handler: Match.absent(),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->
This PR updates the cdk construct to skip setting `AWS_LAMBDA_EXEC_WRAPPER` when the extension is not being used. This env var is set as part of universal instrumentation in Java and .NET with the extension. If the user wants to use only the forwarder, this env var breaks things because the [datadog_wrapper](https://github.com/DataDog/datadog-lambda-extension/blob/main/scripts/datadog_wrapper) script isn't available.

### Motivation

<!--- What inspired you to submit this pull request? --->
See conversation here: https://github.com/DataDog/serverless-plugin-datadog/pull/632

### Testing Guidelines

<!--- How did you test this pull request? --->
Unit tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
