### PR TITLE
fix: Update Log Source to `datadog-agent` on Agent Container

### DIFF
--- a/src/ecs/fargate/datadog-ecs-fargate.ts
+++ b/src/ecs/fargate/datadog-ecs-fargate.ts
@@ -356,7 +356,7 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
     return fluentbitContainer;
   }
 
-  private createLogDriver(serviceName?: string): ecs.FireLensLogDriver | undefined {
+  private createLogDriver(name?: string): ecs.FireLensLogDriver | undefined {
     if (this.datadogProps.logCollection!.loggingType !== LoggingType.FLUENTBIT) {
       return undefined;
     }
@@ -368,7 +368,8 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
 
     // Otherwise, create a FireLenseLogDriver using the provided config
     const fluentbitLogDriverConfig = fluentbitConfig.logDriverConfig!;
-    const logServiceName = serviceName ?? fluentbitLogDriverConfig.serviceName;
+    const logServiceName = name ?? fluentbitLogDriverConfig.serviceName;
+    const logSourceName = name ?? fluentbitLogDriverConfig.sourceName;
 
     let logTags = this.datadogProps.envVarManager.retrieve("DD_TAGS");
     if (this.datadogProps.clusterName !== undefined) {
@@ -394,8 +395,8 @@ export class DatadogECSFargateTaskDefinition extends ecs.FargateTaskDefinition {
         ...(logServiceName !== undefined && {
           dd_service: logServiceName,
         }),
-        ...(fluentbitLogDriverConfig.sourceName !== undefined && {
-          dd_source: fluentbitLogDriverConfig.sourceName,
+        ...(logSourceName !== undefined && {
+          dd_source: logSourceName,
         }),
         ...(fluentbitLogDriverConfig.messageKey !== undefined && {
           dd_message_key: fluentbitLogDriverConfig.messageKey,

--- a/test/ecs/fargate/logging.spec.ts
+++ b/test/ecs/fargate/logging.spec.ts
@@ -141,7 +141,7 @@ describe("DatadogECSFargateLogging", () => {
               dd_tags: "team:cont-p, ecs_cluster_name:test-cluster",
               dd_message_key: "message-test",
               dd_service: "datadog-agent",
-              dd_source: "source-test",
+              dd_source: "datadog-agent",
             }),
           },
         }),


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

<!--- A brief description of the change being made with this pull request. --->

Update firelens log driver on the Agent container to have the `source` be `datadog-agent`

### Motivation

<!--- What inspired you to submit this pull request? --->

Allow the Agent default pipelines to be triggered via the proper source tags for the Agent service

### Testing Guidelines

<!--- How did you test this pull request? --->

Unit tests

### Additional Notes

<!--- Anything else we should know when reviewing? --->

N/A

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
