### PR TITLE
feat: grant decrypt permissions for encrypted secrets passed to apiKeySecret

### DIFF
--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -249,6 +249,7 @@ function setTagsForFunction(lambdaFunction: lambda.Function, props: DatadogLambd
 
 function grantReadLambda(secret: ISecret, lambdaFunction: lambda.Function): void {
   secret.grantRead(lambdaFunction);
+  secret.encryptionKey?.grantDecrypt(lambdaFunction);
 }
 
 function grantReadLambdaFromSecretArn(construct: Construct, arn: string, lambdaFunction: lambda.Function): void {

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -10,12 +10,14 @@ import {
   DD_HANDLER_ENV_VAR,
   DD_TAGS,
 } from "../src/index";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { Key } from "aws-cdk-lib/aws-kms";
 const { ISecret } = require("aws-cdk-lib/aws-secretsmanager");
 const versionJson = require("../version.json");
 const EXTENSION_LAYER_VERSION = 5;
 const CUSTOM_EXTENSION_LAYER_ARN = "arn:aws:lambda:us-east-1:123456789:layer:Datadog-Extension-custom:1";
 const NODE_LAYER_VERSION = 91;
-const REPO_REGEX = /git\.repository_url:.*\/DataDog\/datadog-cdk-constructs(\.git)?/;
+const REPO_REGEX = /git\.repository_url:.*\/[^/]+\/datadog-cdk-constructs(\.git)?/;
 
 describe("validateProps", () => {
   it("throws an error when the site is set to an invalid site URL", () => {
@@ -618,6 +620,50 @@ describe("apiKeySecret", () => {
     expect(datadogLambda.transport.apiKeySecretArn).toEqual(
       "arn:aws:secretsmanager:sa-east-1:123:secret:test-key-from-isecret",
     );
+  });
+
+  it("grants decrypt access to the encryption key when apiKeySecret has an encryption key", () => {
+    const app = new App();
+    const stack = new Stack(app, "stack");
+    const hello = new lambda.Function(stack, "HelloHandler", {
+      runtime: lambda.Runtime.NODEJS_18_X,
+      code: lambda.Code.fromInline("test"),
+      handler: "hello.handler",
+    });
+
+    const secret = new Secret(stack, "DatadogApiKeySecret", {
+      encryptionKey: new Key(stack, "DatadogApiKeySecretKey"),
+    });
+
+    const datadogLambda = new DatadogLambda(stack, "Datadog", {
+      nodeLayerVersion: NODE_LAYER_VERSION,
+      extensionLayerVersion: EXTENSION_LAYER_VERSION,
+      apiKeySecret: secret,
+      enableDatadogTracing: false,
+      flushMetricsToLogs: false,
+    });
+    datadogLambda.addLambdaFunctions([hello]);
+
+    Template.fromStack(stack).hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: [
+          {
+            Action: ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+            Effect: "Allow",
+            Resource: {
+              Ref: "DatadogApiKeySecret1B324DAE",
+            },
+          },
+          {
+            Action: "kms:Decrypt",
+            Effect: "Allow",
+            Resource: {
+              "Fn::GetAtt": ["DatadogApiKeySecretKey14C5CA29", "Arn"],
+            },
+          },
+        ],
+      },
+    });
   });
 });
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Resolves https://github.com/DataDog/datadog-cdk-constructs/issues/249

Grants permissions to the Lambda to decrypt the KMS key in order to access a secret.

### Motivation

We couldn't figure out why our Lambda could not hit DataDog and discovered it was because of the lacking permission.

### Testing Guidelines

Locally + Unit Tests

### Additional Notes

Could be a fix, could be a feature. I don't mind really.

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
