### PR TITLE
feat(ecs): add apiKeySecretField for Secrets Manager API key selection

### DIFF
--- a/src/ecs/interfaces.ts
+++ b/src/ecs/interfaces.ts
@@ -21,6 +21,11 @@ export interface DatadogECSBaseProps {
    */
   readonly apiKeySecret?: secrets.ISecret;
   /**
+   * The JSON field to read from the Datadog API key secret in Secrets Manager.
+   * Applies to `apiKeySecret` and `apiKeySecretArn`.
+   */
+  readonly apiKeySecretField?: string;
+  /**
    * The ARN of the Datadog API key secret.
    * Must define at least 1 source for the API key.
    */

--- a/src/ecs/utils.ts
+++ b/src/ecs/utils.ts
@@ -87,10 +87,10 @@ export function configureEcsPolicies(task: ecs.TaskDefinition) {
 
 export function getSecretApiKey(scope: Construct, props: DatadogECSBaseProps): ecs.Secret | undefined {
   if (props.apiKeySecret) {
-    return ecs.Secret.fromSecretsManager(props.apiKeySecret);
+    return ecs.Secret.fromSecretsManager(props.apiKeySecret, props.apiKeySecretField);
   } else if (props.apiKeySecretArn) {
     const secret = secretsmanager.Secret.fromSecretCompleteArn(scope, "DatadogSecret", props.apiKeySecretArn);
-    return ecs.Secret.fromSecretsManager(secret);
+    return ecs.Secret.fromSecretsManager(secret, props.apiKeySecretField);
   } else if (props.apiKeySsmArn) {
     const parameter = ssm.StringParameter.fromStringParameterAttributes(scope, "DatadogParameter", {
       parameterName: props.apiKeySsmArn,

--- a/test/ecs/fargate/logging.spec.ts
+++ b/test/ecs/fargate/logging.spec.ts
@@ -106,6 +106,7 @@ describe("DatadogECSFargateLogging", () => {
     datadogProps = {
       ...datadogProps,
       clusterName: "test-cluster",
+      apiKeySecretField: "key",
       environmentVariables: {
         DD_TAGS: "team:cont-p",
       },
@@ -143,6 +144,12 @@ describe("DatadogECSFargateLogging", () => {
               dd_service: "datadog-agent",
               dd_source: "datadog-agent",
             }),
+            SecretOptions: Match.arrayWith([
+              Match.objectLike({
+                Name: "apikey",
+                ValueFrom: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-name-AbCdEf:key::",
+              }),
+            ]),
           },
         }),
       ]),

--- a/test/ecs/utils.spec.ts
+++ b/test/ecs/utils.spec.ts
@@ -134,12 +134,32 @@ describe("utils", () => {
       const props = { apiKeySecret: secret };
       const result = getSecretApiKey(scope, props);
       expect(result).toBeDefined();
+      expect(result?.arn).toBe(secret.secretArn);
+    });
+
+    it("should return a secret field from SecretsManager if apiKeySecretField is provided", () => {
+      const secret = secretsmanager.Secret.fromSecretNameV2(scope, "TestSecretWithField", "test-secret");
+      const props = { apiKeySecret: secret, apiKeySecretField: "key" };
+      const result = getSecretApiKey(scope, props);
+      expect(result).toBeDefined();
+      expect(result?.arn).toBe(`${secret.secretArn}:key::`);
     });
 
     it("should return a secret from ARN if apiKeySecretArn is provided", () => {
-      const props = { apiKeySecretArn: "arn:aws:secretsmanager:region:account-id:secret:test-secret" };
+      const props = { apiKeySecretArn: "arn:aws:secretsmanager:region:account-id:secret:test-secret-AbCdEf" };
       const result = getSecretApiKey(scope, props);
       expect(result).toBeDefined();
+      expect(result?.arn).toBe("arn:aws:secretsmanager:region:account-id:secret:test-secret-AbCdEf");
+    });
+
+    it("should return a secret field from ARN if apiKeySecretField is provided", () => {
+      const props = {
+        apiKeySecretArn: "arn:aws:secretsmanager:region:account-id:secret:test-secret-AbCdEf",
+        apiKeySecretField: "key",
+      };
+      const result = getSecretApiKey(scope, props);
+      expect(result).toBeDefined();
+      expect(result?.arn).toBe("arn:aws:secretsmanager:region:account-id:secret:test-secret-AbCdEf:key::");
     });
 
     it("should return a secret from SSM parameter if apiKeySsmArn is provided", () => {


### PR DESCRIPTION
## Summary

This change adds support for Datadog ECS API keys stored as JSON in Secrets Manager.

Today, `apiKeySecret` and `apiKeySecretArn` always resolve the full secret value. That breaks ECS/Fargate setups where the Datadog API key is stored under a JSON field such as:

```json
{
  "key": "..."
}
```

This PR introduces a new optional prop, `apiKeySecretField`, and wires it through the ECS secret resolution path so consumers can select a specific JSON field when building ECS secrets.

## Changes

- Add `apiKeySecretField?: string` to `DatadogECSBaseProps`
- Update `getSecretApiKey()` to pass the optional field into `ecs.Secret.fromSecretsManager(...)`
- Support the field for both:
  - `apiKeySecret`
  - `apiKeySecretArn`
- Add ECS unit tests covering:
  - existing no-field behavior
  - field-based resolution from `apiKeySecret`
  - field-based resolution from `apiKeySecretArn`
- Add a Fargate logging test to verify the synthesized FireLens secret option uses the expected `:field::` Secrets Manager suffix

## Why

Some consumers store the Datadog API key in a structured Secrets Manager payload instead of as a raw string. ECS already supports selecting a JSON field from Secrets Manager secrets, but the construct did not expose that capability.

This change makes that supported explicitly instead of requiring downstream task-definition patching or custom aspects.

## Backward compatibility

This is backward compatible.

If `apiKeySecretField` is not provided, behavior is unchanged:

- `apiKeySecret` continues to resolve the full secret value
- `apiKeySecretArn` continues to resolve the full secret value

The JSON field selector is only applied when `apiKeySecretField` is explicitly set.

## Example

```ts
new DatadogECSFargate({
  apiKeySecret: datadogApiSecret,
  apiKeySecretField: "key",
  // ...
});
```

or

```ts
new DatadogECSFargate({
  apiKeySecretArn: "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-AbCdEf",
  apiKeySecretField: "key",
  // ...
});
```

## Testing

Validated with:

```bash
yarn jest --runInBand test/ecs/utils.spec.ts test/ecs/fargate/logging.spec.ts
```