### PR TITLE
fix: fix upgrade workflow broken by yarn berry migration

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,6 +26,8 @@ jobs:
         run: yarn install --immutable
       - name: Upgrade CDK versions
         run: node scripts/upgrade-cdk.js
+      - name: Disable npm age gate for upgrade
+        run: sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: 20.19.0
+          node-version: 20.16.0
       - name: Install dependencies
         run: yarn install --immutable
       - name: Upgrade CDK versions

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Upgrade CDK versions
         run: node scripts/upgrade-cdk.js
       - name: Disable npm age gate for upgrade
-        run: sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml
+        run: |
+          sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
-          node-version: 20.16.0
+          node-version: 20.19.0
       - name: Install dependencies
         run: yarn install --immutable
       - name: Upgrade CDK versions

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Disable npm age gate for upgrade
         run: |
           sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml
+          echo "enableImmutableInstalls: false" >> .yarnrc.yml
       - name: Upgrade dependencies
         run: npx projen upgrade
       - name: Find mutations

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,12 +26,10 @@ jobs:
         run: yarn install --immutable
       - name: Upgrade CDK versions
         run: node scripts/upgrade-cdk.js
-      - name: Disable npm age gate for upgrade
-        run: |
-          sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml
-          echo "enableImmutableInstalls: false" >> .yarnrc.yml
       - name: Upgrade dependencies
         run: npx projen upgrade
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: "false"
       - name: Find mutations
         id: create_patch
         run: |-

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - name: Enable Corepack
+        run: corepack enable
       - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:

--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -1,0 +1,57 @@
+'use strict';
+// Configuration for npm-check-updates (https://github.com/raineorshine/npm-check-updates).
+// Mirrors the npmMinimalAgeGate: 2d setting in .yarnrc.yml — skips upgrades to versions
+// published less than 2 days ago to guard against first-day supply-chain attacks.
+
+const https = require('https');
+
+const MIN_AGE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
+
+/**
+ * Fetches the publish timestamp for a specific version from the npm registry.
+ * @param {string} name - Package name (scoped or unscoped)
+ * @param {string} version - Exact version string
+ * @returns {Promise<Date | null>}
+ */
+function fetchPublishDate(name, version) {
+  // Encode scoped names: @scope/pkg -> @scope%2Fpkg
+  const encoded = name.startsWith('@') ? `@${encodeURIComponent(name.slice(1))}` : name;
+  return new Promise((resolve) => {
+    const req = https.get(`https://registry.npmjs.org/${encoded}`, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        return resolve(null);
+      }
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        try {
+          const meta = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+          const ts = meta.time?.[version];
+          resolve(ts ? new Date(ts) : null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    req.on('error', () => resolve(null));
+    // Abort after 15 s to avoid hanging the upgrade run.
+    req.setTimeout(15_000, () => { req.destroy(); resolve(null); });
+  });
+}
+
+/** @type {import('npm-check-updates').RunOptions} */
+module.exports = {
+  filterResults: async (name, { upgradedVersion }) => {
+    if (!upgradedVersion) return false;
+    const published = await fetchPublishDate(name, upgradedVersion);
+    if (!published) return true; // unknown age — fail open
+    const ageMs = Date.now() - published.getTime();
+    if (ageMs < MIN_AGE_MS) {
+      const ageDays = (ageMs / (1000 * 60 * 60 * 24)).toFixed(1);
+      console.log(`Skipping ${name}@${upgradedVersion} — published ${ageDays}d ago (minimum: 2d)`);
+      return false;
+    }
+    return true;
+  },
+};

--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -1,67 +1,72 @@
 'use strict';
 // Configuration for npm-check-updates (https://github.com/raineorshine/npm-check-updates).
-// Mirrors the npmMinimalAgeGate: 2d setting in .yarnrc.yml — skips upgrades to versions
-// published less than 2 days ago to guard against first-day supply-chain attacks.
+// Mirrors the npmMinimalAgeGate: 2d setting in .yarnrc.yml — skips upgrades to packages
+// whose latest published version is less than 2 days old, guarding against first-day
+// supply-chain attacks.
 //
-// NOTE: filterResults must be synchronous. ncu does not await async callbacks, so
-// an async function always returns a truthy Promise and the filter has no effect.
-// We use execSync + a child node process to make the HTTP call synchronous.
+// We use `reject` (a static list built at load time) rather than `filterResults` because
+// ncu does not apply `filterResults` to the package.json write when invoked via --upgrade
+// from a config file; it only filters the programmatic return value of ncu.run().
 
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const MIN_AGE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
 
 /**
- * Fetches the publish timestamp for a specific npm package version synchronously
- * by spawning a child Node.js process that makes the HTTPS request.
+ * Returns the packages in ncu's --filter list by reading .projen/tasks.json.
+ */
+function getNcuFilterPackages() {
+  try {
+    const tasks = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), '.projen', 'tasks.json'), 'utf8'),
+    );
+    const exec = tasks?.tasks?.upgrade?.steps?.[0]?.exec ?? '';
+    const m = exec.match(/--filter=(\S+)/);
+    return m ? m[1].split(',') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Synchronously returns the publish date of a package's `latest` dist-tag version.
+ * Spawns a child node process to make the HTTPS call synchronously.
+ * The inline script is kept on a single line because multiline strings
+ * serialized with JSON.stringify produce literal \n sequences that the shell
+ * passes as two characters (\\ and n), which are not statement separators in JS.
  * Returns null when the date cannot be determined (fail open).
  */
-function getPublishDateSync(name, version) {
-  // Encode scoped names: @scope/pkg -> @scope%2Fpkg
+function getLatestPublishDateSync(name) {
   const encoded = name.startsWith('@') ? '@' + encodeURIComponent(name.slice(1)) : name;
-
-  // Inline script run in a child process — keep it on one logical block so
-  // JSON.stringify handles all escaping for us when it becomes a CLI argument.
-  const script = `
-const https = require('https');
-const chunks = [];
-const req = https.get('https://registry.npmjs.org/' + ${JSON.stringify(encoded)}, (res) => {
-  res.on('data', (c) => chunks.push(c));
-  res.on('end', () => {
-    try {
-      const m = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-      process.stdout.write((m.time && m.time[${JSON.stringify(version)}]) || '');
-    } catch { process.stdout.write(''); }
-  });
-});
-req.on('error', () => process.stdout.write(''));
-req.setTimeout(10000, () => { process.stdout.write(''); process.exit(0); });
-`.trim();
-
+  const url = `https://registry.npmjs.org/${encoded}`;
+  // prettier-ignore
+  const script = `const https=require('https'),chunks=[];const req=https.get(${JSON.stringify(url)},(res)=>{res.on('data',(c)=>chunks.push(c));res.on('end',()=>{try{const m=JSON.parse(Buffer.concat(chunks).toString('utf8'));const l=m['dist-tags']&&m['dist-tags'].latest;process.stdout.write((l&&m.time&&m.time[l])||'');}catch{process.stdout.write('');}});});req.on('error',()=>process.stdout.write(''));req.setTimeout(10000,()=>{process.stdout.write('');process.exit(0);});`;
   try {
-    const result = execSync(`node -e ${JSON.stringify(script)}`, {
+    const out = execSync(`node -e ${JSON.stringify(script)}`, {
       timeout: 15000,
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    return result.trim() ? new Date(result.trim()) : null;
+    return out.trim() ? new Date(out.trim()) : null;
   } catch {
     return null;
   }
 }
 
+// Build the reject list synchronously at module load time, before ncu resolves versions.
+const reject = [];
+for (const pkg of getNcuFilterPackages()) {
+  const published = getLatestPublishDateSync(pkg);
+  if (!published) continue; // cannot determine age — fail open
+  const ageMs = Date.now() - published.getTime();
+  if (ageMs < MIN_AGE_MS) {
+    const ageDays = (ageMs / (1000 * 60 * 60 * 24)).toFixed(1);
+    console.log(`ncu-age-filter: skipping ${pkg} — latest published ${ageDays}d ago (minimum: 2d)`);
+    reject.push(pkg);
+  }
+}
+
 /** @type {import('npm-check-updates').RunOptions} */
-module.exports = {
-  filterResults: (name, { upgradedVersion }) => {
-    if (!upgradedVersion) return false;
-    const published = getPublishDateSync(name, upgradedVersion);
-    if (!published) return true; // unknown age — fail open
-    const ageMs = Date.now() - published.getTime();
-    if (ageMs < MIN_AGE_MS) {
-      const ageDays = (ageMs / (1000 * 60 * 60 * 24)).toFixed(1);
-      console.log(`Skipping ${name}@${upgradedVersion} — published ${ageDays}d ago (minimum: 2d)`);
-      return false;
-    }
-    return true;
-  },
-};
+module.exports = { reject };

--- a/.ncurc.cjs
+++ b/.ncurc.cjs
@@ -2,49 +2,59 @@
 // Configuration for npm-check-updates (https://github.com/raineorshine/npm-check-updates).
 // Mirrors the npmMinimalAgeGate: 2d setting in .yarnrc.yml — skips upgrades to versions
 // published less than 2 days ago to guard against first-day supply-chain attacks.
+//
+// NOTE: filterResults must be synchronous. ncu does not await async callbacks, so
+// an async function always returns a truthy Promise and the filter has no effect.
+// We use execSync + a child node process to make the HTTP call synchronous.
 
-const https = require('https');
+const { execSync } = require('child_process');
 
 const MIN_AGE_MS = 2 * 24 * 60 * 60 * 1000; // 2 days
 
 /**
- * Fetches the publish timestamp for a specific version from the npm registry.
- * @param {string} name - Package name (scoped or unscoped)
- * @param {string} version - Exact version string
- * @returns {Promise<Date | null>}
+ * Fetches the publish timestamp for a specific npm package version synchronously
+ * by spawning a child Node.js process that makes the HTTPS request.
+ * Returns null when the date cannot be determined (fail open).
  */
-function fetchPublishDate(name, version) {
+function getPublishDateSync(name, version) {
   // Encode scoped names: @scope/pkg -> @scope%2Fpkg
-  const encoded = name.startsWith('@') ? `@${encodeURIComponent(name.slice(1))}` : name;
-  return new Promise((resolve) => {
-    const req = https.get(`https://registry.npmjs.org/${encoded}`, (res) => {
-      if (res.statusCode !== 200) {
-        res.resume();
-        return resolve(null);
-      }
-      const chunks = [];
-      res.on('data', (c) => chunks.push(c));
-      res.on('end', () => {
-        try {
-          const meta = JSON.parse(Buffer.concat(chunks).toString('utf8'));
-          const ts = meta.time?.[version];
-          resolve(ts ? new Date(ts) : null);
-        } catch {
-          resolve(null);
-        }
-      });
-    });
-    req.on('error', () => resolve(null));
-    // Abort after 15 s to avoid hanging the upgrade run.
-    req.setTimeout(15_000, () => { req.destroy(); resolve(null); });
+  const encoded = name.startsWith('@') ? '@' + encodeURIComponent(name.slice(1)) : name;
+
+  // Inline script run in a child process — keep it on one logical block so
+  // JSON.stringify handles all escaping for us when it becomes a CLI argument.
+  const script = `
+const https = require('https');
+const chunks = [];
+const req = https.get('https://registry.npmjs.org/' + ${JSON.stringify(encoded)}, (res) => {
+  res.on('data', (c) => chunks.push(c));
+  res.on('end', () => {
+    try {
+      const m = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      process.stdout.write((m.time && m.time[${JSON.stringify(version)}]) || '');
+    } catch { process.stdout.write(''); }
   });
+});
+req.on('error', () => process.stdout.write(''));
+req.setTimeout(10000, () => { process.stdout.write(''); process.exit(0); });
+`.trim();
+
+  try {
+    const result = execSync(`node -e ${JSON.stringify(script)}`, {
+      timeout: 15000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return result.trim() ? new Date(result.trim()) : null;
+  } catch {
+    return null;
+  }
 }
 
 /** @type {import('npm-check-updates').RunOptions} */
 module.exports = {
-  filterResults: async (name, { upgradedVersion }) => {
+  filterResults: (name, { upgradedVersion }) => {
     if (!upgradedVersion) return false;
-    const published = await fetchPublishDate(name, upgradedVersion);
+    const published = getPublishDateSync(name, upgradedVersion);
     if (!published) return true; // unknown age — fail open
     const ageMs = Date.now() - published.getTime();
     if (ageMs < MIN_AGE_MS) {

--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 /scripts
 /integration_tests
 .prettierrc
+/.ncurc.cjs
 cdk.out/*
 yarn-error.log
 CHANGELOG.md

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -164,6 +164,17 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   }),
 );
 
+// Temporarily disable the npmMinimalAgeGate before running `projen upgrade`,
+// so that ncu can resolve and install newly-published package versions.
+// The gate is restored automatically when `npx projen` runs at the end of
+// the upgrade task and regenerates .yarnrc.yml from .projenrc.js.
+project.github?.tryFindWorkflow("upgrade")?.file?.patch(
+  JsonPatch.add("/jobs/upgrade/steps/5", {
+    name: "Disable npm age gate for upgrade",
+    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml",
+  }),
+);
+
 const eslintConfig = project.tryFindObjectFile(".eslintrc.json");
 eslintConfig.addOverride("extends", [
   "plugin:@typescript-eslint/recommended",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -17,7 +17,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
       nodeLinker: javascript.YarnNodeLinker.NODE_MODULES,
     },
   },
-  minNodeVersion: "20.16.0",
+  minNodeVersion: "20.19.0",
 
   jsiiFqn: "projen.AwsCdkConstructLibrary",
   defaultReleaseBranch: "main",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -17,7 +17,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
       nodeLinker: javascript.YarnNodeLinker.NODE_MODULES,
     },
   },
-  minNodeVersion: "20.19.0",
+  minNodeVersion: "20.16.0",
 
   jsiiFqn: "projen.AwsCdkConstructLibrary",
   defaultReleaseBranch: "main",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -171,7 +171,7 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
 project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   JsonPatch.add("/jobs/upgrade/steps/5", {
     name: "Disable npm age gate for upgrade",
-    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml",
+    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml\n",
   }),
 );
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -77,6 +77,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     "/scripts",
     "/integration_tests",
     ".prettierrc",
+    "/.ncurc.cjs",
     "cdk.out/*",
     "yarn-error.log",
     "CHANGELOG.md",
@@ -164,14 +165,13 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   }),
 );
 
-// Temporarily disable the npmMinimalAgeGate before running `projen upgrade`,
-// so that ncu can resolve and install newly-published package versions.
-// The gate is restored automatically when `npx projen` runs at the end of
-// the upgrade task and regenerates .yarnrc.yml from .projenrc.js.
+// The projen upgrade task sets CI=0 to allow the lockfile to be updated, but
+// Yarn 4.x treats any non-empty CI string as truthy and keeps immutable installs
+// active. Override via the YARN_ENABLE_IMMUTABLE_INSTALLS env var instead, scoped
+// only to the upgrade step so the setting never leaks into normal installs.
 project.github?.tryFindWorkflow("upgrade")?.file?.patch(
-  JsonPatch.add("/jobs/upgrade/steps/5", {
-    name: "Disable npm age gate for upgrade",
-    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml\necho \"enableImmutableInstalls: false\" >> .yarnrc.yml\n",
+  JsonPatch.add("/jobs/upgrade/steps/5/env", {
+    YARN_ENABLE_IMMUTABLE_INSTALLS: "false",
   }),
 );
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -171,7 +171,7 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
 project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   JsonPatch.add("/jobs/upgrade/steps/5", {
     name: "Disable npm age gate for upgrade",
-    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml\n",
+    run: "sed -i 's/npmMinimalAgeGate:.*/npmMinimalAgeGate: 0/' .yarnrc.yml\necho \"enableImmutableInstalls: false\" >> .yarnrc.yml\n",
   }),
 );
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -142,12 +142,23 @@ project.github?.tryFindWorkflow("upgrade")?.file?.patch(
   }),
 );
 
-// Patch the upgrade workflow since its managed by projen
-// to add a step to upgrade the CDK versions.  3 happens to
-// be the index after install dependencies and before the
-// other dependency upgrade step.
+// Patch the upgrade workflow to enable Corepack before setup-node, so that
+// setup-node can detect the yarn berry package manager (from the packageManager
+// field in package.json) and set up caching correctly.
 project.github?.tryFindWorkflow("upgrade")?.file?.patch(
-  JsonPatch.add("/jobs/upgrade/steps/3", {
+  JsonPatch.add("/jobs/upgrade/steps/1", {
+    name: "Enable Corepack",
+    run: "corepack enable",
+  }),
+);
+
+// Patch the upgrade workflow since its managed by projen
+// to add a step to upgrade the CDK versions.  4 happens to
+// be the index after install dependencies and before the
+// other dependency upgrade step (shifted by 1 due to the
+// Enable Corepack step inserted above).
+project.github?.tryFindWorkflow("upgrade")?.file?.patch(
+  JsonPatch.add("/jobs/upgrade/steps/4", {
     name: "Upgrade CDK versions",
     run: "node scripts/upgrade-cdk.js",
   }),

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 20.16.0"
+    "node": ">= 20.19.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 20.19.0"
+    "node": ">= 20.16.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

The weekly upgrade workflow was broken by the yarn berry migration (#577). Three issues:

- **Missing `corepack enable`** — `actions/setup-node` v5 auto-detects `packageManager: "yarn@4.12.0"` from `package.json` and runs `yarn cache dir` to set up caching, but the system yarn (1.22.x) rejects the project without Corepack active; added `corepack enable` before `setup-node`
- **Immutable installs in CI** — Yarn 4.x uses `is-ci` which treats any non-empty `CI` string (including `"0"`) as truthy, so the projen upgrade task's `CI=0` env override does not disable immutable installs; fixed with `YARN_ENABLE_IMMUTABLE_INSTALLS=false` scoped to the upgrade step
- **`npmMinimalAgeGate: 2d` blocking newly-published packages** — ncu can bump `package.json` to a version published minutes ago, which yarn then rejects; added `.ncurc.cjs` that builds a `reject` list at load time by checking the npm registry for each package's latest publish date and excluding those < 2 days old — preserving the age gate without disabling it

### Why `reject` and not `filterResults`

`filterResults` in ncu's config file does not prevent the `package.json` write when ncu is invoked via `--upgrade`; it only filters the programmatic return value of `ncu.run()`. The `reject` option actually blocks the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

I don't know how this PR fixed it, but it seems to work: https://github.com/DataDog/datadog-cdk-constructs/actions/runs/24349765287
<img width="592" height="158" alt="image" src="https://github.com/user-attachments/assets/9056c1e3-1694-44d2-8abf-e8846e5d7d95" />


The failure for "Create Pull Request" should be gone after this PR is merged and the workflow runs from main branch.