### PR TITLE
chore: fix release process

### DIFF
--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -14,10 +14,20 @@ elif [[ ! $RELEASE_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     exit 1
 fi
 
+# Make sure local tags are up to date with the remote before anything else,
+# otherwise `git describe` below can fail and produce an empty commit list.
+git fetch origin 'refs/tags/*:refs/tags/*' --quiet
+
 # Check that the release version has not already been published
 MATCHING_GITHUB_VERSION=$(git tag -l | grep $RELEASE_VERSION)
 if [ $MATCHING_GITHUB_VERSION ]; then
     echo "ERROR: Version $MATCHING_GITHUB_VERSION already exists"
+    exit 1
+fi
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+if [ -z "$LAST_TAG" ]; then
+    echo "ERROR: Could not find a previous tag via git describe. Aborting."
     exit 1
 fi
 
@@ -28,7 +38,7 @@ jq --arg v "$RELEASE_VERSION" '.version = $v' "$VERSION_FILE" > "$VERSION_FILE.t
 git add $VERSION_FILE
 
 # Create a commit with all of the commit info for commits in this release
-INCLUDED_COMMITS=$(git log $(git describe --tags --abbrev=0)..HEAD --no-merges --oneline)
+INCLUDED_COMMITS=$(git log "$LAST_TAG"..HEAD --no-merges --oneline)
 git commit -m "chore: Release v2-$RELEASE_VERSION
 
 This release includes the following commits:


### PR DESCRIPTION
### What does this PR do?

Hardens `scripts/create_release.sh` so the release commit body always contains the included-commit list:

- Fetches tags from `origin` before computing the previous release tag, so a local clone with stale/missing tags doesn't silently produce an empty commit list.
- Captures `git describe --tags --abbrev=0` into `LAST_TAG` once and aborts with a clear error if it is empty, instead of proceeding with a broken `git log ..HEAD` invocation.

### Motivation

While cutting `v2-3.11.0`, `git describe --tags --abbrev=0` failed with `fatal: No names found, cannot describe anything.` because no `v2-*` tags were present locally. The script kept going, and the release commit was pushed with an empty "This release includes the following commits:" section (the tag + release branch push still succeeded, so the failure was easy to miss).

### Testing Guidelines

- Run `yarn create-release <next-version>` from a clone with no local tags -- tags are fetched, `LAST_TAG` resolves, and the commit body lists all commits since the previous tag.


### Additional Notes

No behavior change in the happy path beyond a one-time `git fetch` of tags.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog