### PR TITLE
fix: prevent TypeError in setGitEnvironmentVariables with CDK 2.253+

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -61,14 +61,16 @@ export function setGitEnvironmentVariables(
 
   if (hash == "" || gitRepoUrl == "") return;
 
-  // We're using an any type here because AWS does not expose the `environment` field in their type
+  // Build the git metadata tag value
+  const gitTags = `git.commit.sha:${hash},git.repository_url:${gitRepoUrl}`;
+
   lambdas.forEach((lam) => {
-    if (lam.environment[DD_TAGS] !== undefined) {
-      lam.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
+    const existingDdTags = lam.environment[DD_TAGS]?.value;
+    if (existingDdTags) {
+      lam.addEnvironment(DD_TAGS, `${existingDdTags},${gitTags}`);
     } else {
-      lam.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
+      lam.addEnvironment(DD_TAGS, gitTags);
     }
-    lam.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #596 — `DatadogLambda.addLambdaFunctions()` crashes with `TypeError: Cannot read properties of undefined (reading 'value')` when used with `aws-cdk-lib >= 2.253.0`.

## Root Cause

In `src/env.ts`, `setGitEnvironmentVariables()` accesses the internal `lam.environment[DD_TAGS].value` property unconditionally on line 71, after the `else` branch calls `lam.addEnvironment()`:

```typescript
// Before (broken with CDK 2.253+)
lambdas.forEach((lam) => {
    if (lam.environment[DD_TAGS] !== undefined) {
        lam.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
    } else {
        lam.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
    }
    // This line crashes — after addEnvironment(), the internal
    // .environment structure in CDK 2.253 doesn't expose .value
    lam.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
});
```

In `aws-cdk-lib@2.253.0`, the internal `environment` property structure on Lambda functions changed. After calling `addEnvironment()`, `lam.environment[DD_TAGS]` may not have a `.value` property, causing the TypeError.

## Fix

Use `addEnvironment()` via the public API consistently instead of directly mutating the internal `.environment` property:

```typescript
// After (works with all CDK versions)
const gitTags = `git.commit.sha:${hash},git.repository_url:${gitRepoUrl}`;

lambdas.forEach((lam) => {
    const existingDdTags = lam.environment[DD_TAGS]?.value;
    if (existingDdTags) {
        lam.addEnvironment(DD_TAGS, `${existingDdTags},${gitTags}`);
    } else {
        lam.addEnvironment(DD_TAGS, gitTags);
    }
});
```

Key changes:
- Uses optional chaining (`?.value`) to safely read existing value
- Builds the full git tags string upfront (both `git.commit.sha` and `git.repository_url`)
- Uses `addEnvironment()` for all writes — never directly mutates `.value`
- Simpler code — no split between setting sha and repo url

## Tests

All 240 existing tests pass, including the 4 `DD_TAGS` tests that verify:
- `git.commit.sha` and `git.repository_url` are set by default
- Existing `DD_TAGS` values are preserved when adding git metadata
- Source code integration can be disabled

## Workaround

For users who need an immediate fix before this is released:

```typescript
const datadog = new DatadogLambda(this, "Datadog", {
    // ... other props
    sourceCodeIntegration: false,
});
```