### PR TITLE
fix: bugs on setGitEnvironmentVariables

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -55,20 +55,20 @@ export function setGitEnvironmentVariables(
     hash = gitCommitShaOverride;
   }
   if (gitRepoUrlOverride) {
-    log.debug(`Using git repo URL override.  Will be ${gitRepoUrlOverride} instead of ${hash}`);
+    log.debug(`Using git repo URL override.  Will be ${gitRepoUrlOverride} instead of ${gitRepoUrl}`);
     gitRepoUrl = gitRepoUrlOverride;
   }
 
   if (hash == "" || gitRepoUrl == "") return;
 
   // We're using an any type here because AWS does not expose the `environment` field in their type
+  const gitTags = `git.commit.sha:${hash},git.repository_url:${gitRepoUrl}`;
   lambdas.forEach((lam) => {
-    if (lam.environment[DD_TAGS] !== undefined) {
-      lam.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
+    if (lam.environment[DD_TAGS] === undefined) {
+      lam.addEnvironment(DD_TAGS, gitTags);
     } else {
-      lam.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
+      lam.environment[DD_TAGS].value += `,${gitTags}`;
     }
-    lam.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
   });
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes a `TypeError: Cannot read properties of undefined (reading 'value')` crash in `setGitEnvironmentVariables` when `DD_TAGS` is not already set on the lambda function.

Also fixes a minor log message bug in the `gitRepoUrlOverride` debug statement, which was logging `hash` instead of `gitRepoUrl` as the "instead of" value.

### Motivation

The `else` branch of the `DD_TAGS` check calls `lam.addEnvironment(DD_TAGS, ...)` to set the sha, then immediately reads back `lam.environment[DD_TAGS].value` on the following line to append the repo URL. Because `lam.environment` is a private CDK field accessed via `any` cast, this read-back is not guaranteed to reflect the value just written by `addEnvironment` - in particular, it fails when there is a CDK peer dependency version mismatch between the consuming project and the version this library was tested against. The result is a hard crash at CDK synth time that completely prevents deployment.

The root cause is that the two git tags (`git.commit.sha` and `git.repository_url`) are set in two separate operations, but the second operation always uses the private field read - even when the first operation went through the public `addEnvironment` API (the `else` branch). 

### Testing Guidelines

Existing unit tests covering `setGitEnvironmentVariables` continue to pass. The fix is behaviorally identical for the case where `DD_TAGS` is already set (private field is read, confirmed non-undefined, then appended to - unchanged). For the case where `DD_TAGS` is not yet set, both git tags are now written atomically in a single `addEnvironment` call, eliminating the unsafe read-back.

### Additional Notes

The unconditional line 71 (`lam.environment[DD_TAGS].value += ...`) was always unsafe after the `else` branch because `addEnvironment` is a public method that may not synchronously update the private `environment` map in all CDK versions. Combining both tags into a single value in both branches removes this assumption entirely.

### Types of Changes

- [x] Bug fix

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR's changes are covered by the automated tests