### PR TITLE
fix: Update tag setting to use addEnvironment API

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -30,6 +30,16 @@
       "type": "build"
     },
     {
+      "name": "aws-cdk-lib",
+      "version": "2.253.0",
+      "type": "build"
+    },
+    {
+      "name": "constructs",
+      "version": "10.5.1",
+      "type": "build"
+    },
+    {
       "name": "esbuild",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -224,7 +224,7 @@
           "exec": "yarn install --no-immutable"
         },
         {
-          "exec": "yarn up -R @aws-cdk/aws-lambda-python-alpha @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-pacmak jsii-rosetta jsii prettier projen standard-version ts-jest ts-node typescript loglevel aws-cdk-lib constructs"
+          "exec": "yarn up -R @aws-cdk/aws-lambda-python-alpha @stylistic/eslint-plugin @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs esbuild eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii-diff jsii-pacmak jsii-rosetta jsii prettier projen standard-version ts-jest ts-node typescript loglevel"
         },
         {
           "exec": "yarn projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,6 +36,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
     mavenArtifactId: "datadog-cdk-constructs",
   },
   peerDeps: [],
+  peerDependencyOptions: {
+    pinnedDevDependency: false,
+  },
   cdkVersion: "2.245.0",
   cdkCliVersion: "^2.245.0",
   deps: ["loglevel"],
@@ -109,6 +112,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
     },
   },
 });
+
+project.addDevDeps("aws-cdk-lib@2.253.0", "constructs@10.5.1");
 
 // Pin GitHub Actions to commit SHAs instead of tags
 project.github.actions.set(

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.245.0",
+    "aws-cdk-lib": "2.253.0",
     "constructs": "10.5.1",
     "esbuild": "^0.28.0",
     "eslint": "^9",

--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -192,10 +192,11 @@ export class DatadogLambda extends Construct {
     // If any lambdas have already been added, override the commit sha and url
     if (this.lambdas) {
       this.lambdas.forEach((lambdaFunction: any) => {
-        if (lambdaFunction.environment[DD_TAGS] === undefined) {
+        const existingTags = lambdaFunction.environment[DD_TAGS] ?? lambdaFunction.environment.map?.get?.(DD_TAGS);
+        if (existingTags === undefined) {
           return;
         }
-        const tags = lambdaFunction.environment[DD_TAGS].value.split(",");
+        const tags = existingTags.value.split(",");
         if (gitCommitSha) {
           const index = tags.findIndex((val: string) => val.split(":")[0] === "git.commit.sha");
           tags[index] = `git.commit.sha:${gitCommitSha}`;
@@ -206,7 +207,7 @@ export class DatadogLambda extends Construct {
           tags[index] = `git.repository_url:${gitRepoUrl}`;
         }
 
-        lambdaFunction.environment[DD_TAGS].value = tags.join(",");
+        lambdaFunction.addEnvironment(DD_TAGS, tags.join(","));
       });
     }
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -63,12 +63,10 @@ export function setGitEnvironmentVariables(
 
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lam) => {
-    if (lam.environment[DD_TAGS] !== undefined) {
-      lam.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
-    } else {
-      lam.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
-    }
-    lam.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
+    const tagsValue = `git.commit.sha:${hash},git.repository_url:${gitRepoUrl}`;
+    const existingTagValue = lam.environment[DD_TAGS]?.value ?? lam.environment.map?.get?.(DD_TAGS)?.value;
+    const finalTagValue = existingTagValue ? `${existingTagValue},${tagsValue}` : tagsValue;
+    lam.addEnvironment(DD_TAGS, finalTagValue);
   });
 }
 
@@ -123,7 +121,8 @@ export function applyEnvVariables(lam: lambda.Function, baseProps: DatadogLambda
   log.debug(`Setting environment variables...`);
   const lam_with_env_vars: any = lam; //cast to any to access the private environment fields like in setGitEnvironmentVariables
   const setEnvIfUndefined = (envVar: string, value: string | boolean) => {
-    if (lam_with_env_vars.environment[envVar] === undefined) {
+    const existingEnvVar = lam_with_env_vars.environment[envVar] ?? lam_with_env_vars.environment.map?.get?.(envVar);
+    if (existingEnvVar === undefined) {
       lam.addEnvironment(envVar, value.toString().toLowerCase());
     }
   };

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -854,10 +854,10 @@ describe("overrideGitMetadata", () => {
     });
     datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
     datadogLambda.addLambdaFunctions([hello], stack);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.repository_url:fake-url"]),
     );
   });
@@ -880,10 +880,10 @@ describe("overrideGitMetadata", () => {
     });
     datadogLambda.addLambdaFunctions([hello], stack);
     datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.repository_url:fake-url"]),
     );
   });
@@ -913,10 +913,10 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.commit.sha:fake-sha"]),
       );
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.repository_url:fake-url"]),
       );
     });
@@ -949,10 +949,10 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.commit.sha:fake-sha"]),
       );
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(expect.arrayContaining(["testVar:xyz"]));
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(expect.arrayContaining(["testVar:xyz"]));
     });
   });
 
@@ -982,7 +982,7 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining([expect.stringContaining("git.commit.sha:fake-sha"), expect.stringMatching(REPO_REGEX)]),
       );
     });
@@ -1007,9 +1007,12 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([hello], stack);
 
     expect(
-      (<any>hello).environment[DD_TAGS].value.split(",").some((item: string) => item.includes("git.commit.sha")),
+      (<any>hello).environment.map
+        .get(DD_TAGS)
+        .value.split(",")
+        .some((item: string) => item.includes("git.commit.sha")),
     ).toEqual(true);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining([expect.stringMatching(REPO_REGEX)]),
     );
   });
@@ -1036,7 +1039,7 @@ describe("overrideGitMetadata", () => {
     });
 
     datadogLambda.addLambdaFunctions([hello], stack);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@aws-cdk/asset-awscli-v1@npm:2.2.263":
-  version: 2.2.263
-  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.263"
-  checksum: 10c0/d84d00fa1f576a7774a15f30431675fe174e2d42369117bf6b336c33b89525d61628364c084460029b23fa404b73474559af2274773e9e4f06be962f322690ff
+"@aws-cdk/asset-awscli-v1@npm:2.2.273":
+  version: 2.2.273
+  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.273"
+  checksum: 10c0/625f12bc6c659efcafdc135c0efcf0e780d4c33fbcbcf9cbcdef20b76d3cd7cfdf51c49306d7b65e37d58c6a4c1b20a15dac28a00bae55da10ccb01ade8a033b
   languageName: node
   linkType: hard
 
@@ -29,25 +29,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-api@npm:^2.2.0":
-  version: 2.2.2
-  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.2"
+"@aws-cdk/cloud-assembly-api@npm:^2.2.2":
+  version: 2.2.3
+  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.3"
   dependencies:
     jsonschema: "npm:~1.4.1"
     semver: "npm:^7.7.4"
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
-  checksum: 10c0/cc5e7edd13d9d7e4ad7878c16f85a1a15c68e9ec51b71ad4a4c884ef0b3ed28fc25dc0627f0c226d65615cc6011ca02de94401862b650a996f8ccdff651e4d44
+    "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+  checksum: 10c0/3f9309a28ef6e7ba62ed83925d8471b3141e991ec895f7b0340a5baa6a57cab1408e6876203cea2f8e6db75cf9785248e4015b4dca8c941b0c0ea2fc7900b8ea
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:^53.0.0":
-  version: 53.18.0
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:53.18.0"
+"@aws-cdk/cloud-assembly-schema@npm:^53.18.0":
+  version: 53.22.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:53.22.0"
   dependencies:
     jsonschema: "npm:~1.4.1"
     semver: "npm:^7.7.4"
-  checksum: 10c0/f8e2f7f7f603f6ef9e8ec1a5c87d9b24f0011995a08153b336deba9fb0cac5235a97c0846b84f960fef34631a1c48808e13fdfa623eceb798e062d8a60c8a39f
+  checksum: 10c0/cf7482b435e43b750d35195f6567ba8af1c2d75e54449cacf1a38ce0d7c7dfcae47e05c373e66d396fa8a278e03e797b8b495467c1f3e6dd763b235a96b0c0db
   languageName: node
   linkType: hard
 
@@ -2223,14 +2223,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:2.245.0":
-  version: 2.245.0
-  resolution: "aws-cdk-lib@npm:2.245.0"
+"aws-cdk-lib@npm:2.253.0":
+  version: 2.253.0
+  resolution: "aws-cdk-lib@npm:2.253.0"
   dependencies:
-    "@aws-cdk/asset-awscli-v1": "npm:2.2.263"
+    "@aws-cdk/asset-awscli-v1": "npm:2.2.273"
     "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.1"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.0"
-    "@aws-cdk/cloud-assembly-schema": "npm:^53.0.0"
+    "@aws-cdk/cloud-assembly-api": "npm:^2.2.2"
+    "@aws-cdk/cloud-assembly-schema": "npm:^53.18.0"
     "@balena/dockerignore": "npm:^1.0.2"
     case: "npm:1.6.3"
     fs-extra: "npm:^11.3.3"
@@ -2244,7 +2244,7 @@ __metadata:
     yaml: "npm:1.10.3"
   peerDependencies:
     constructs: ^10.5.0
-  checksum: 10c0/af558d5355524b977d363650aab2902ea7b5337319a181babc1ab10180c8c9e0f481f51661012c201f077bf1b21ac851c5396912a55baff9876ce370a4e53c1d
+  checksum: 10c0/dceca4b559c81aaf28a2cb2fd2581d61ee9e5555b31fba255ac2145db66e582c3e1a276d28ba8019cae334813e67e1676be91f07420877d01a6f76cb83a50176
   languageName: node
   linkType: hard
 
@@ -3022,7 +3022,7 @@ __metadata:
     "@types/node": "npm:^22"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
-    aws-cdk-lib: "npm:2.245.0"
+    aws-cdk-lib: "npm:2.253.0"
     constructs: "npm:10.5.1"
     esbuild: "npm:^0.28.0"
     eslint: "npm:^9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,14 +2000,14 @@ __metadata:
   linkType: hard
 
 "ajv@npm:^8.0.1":
-  version: 8.18.0
-  resolution: "ajv@npm:8.18.0"
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     fast-uri: "npm:^3.0.1"
     json-schema-traverse: "npm:^1.0.0"
     require-from-string: "npm:^2.0.2"
-  checksum: 10c0/e7517c426173513a07391be951879932bdf3348feaebd2199f5b901c20f99d60db8cd1591502d4d551dc82f594e82a05c4fe1c70139b15b8937f7afeaed9532f
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 
@@ -3895,9 +3895,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
   languageName: node
   linkType: hard
 
@@ -4044,13 +4044,13 @@ __metadata:
   linkType: hard
 
 "fs-extra@npm:^11.3.3":
-  version: 11.3.3
-  resolution: "fs-extra@npm:11.3.3"
+  version: 11.3.5
+  resolution: "fs-extra@npm:11.3.5"
   dependencies:
     graceful-fs: "npm:^4.2.0"
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
-  checksum: 10c0/984924ff4104e3e9f351b658a864bf3b354b2c90429f57aec0acd12d92c4e6b762cbacacdffb4e745b280adce882e1f980c485d9f02c453f769ab4e7fc646ce3
+  checksum: 10c0/33e80bad6b5d17308faa197e5ede99ecba4b6f6cb4aa4645d52745476c75afc57665bdf39ec75b2ebb38b97b7110f634a8dcc0a546e248eb4de059275cf5ac90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Resolves https://github.com/DataDog/datadog-cdk-constructs/issues/596

<!--- A brief description of the change being made with this pull request. --->

### Motivation

My CI is broken: https://github.com/seek-oss/skuba/actions/runs/25618922361/job/75201906880

### Testing Guidelines

- I updated aws-cdk-lib to the problematic version and ran `yarn test`.
- I also used the previous version of aws-cdk-lib, reverted my test changes and ran `yarn test` to verify backwards compatibility

### Additional Notes

Unlike the other PRs, this isn't vibe coded...

This PR handles both older versions of aws-cdk-lib and newer versions but if you'd prefer a cleaner interface you can view the breaking change alternative here: https://github.com/DataDog/datadog-cdk-constructs/pull/601

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
