### PR TITLE
fix!: Update tag setting to use addEnvironment for CDK 2.253.0

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -111,7 +111,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.245.0",
+      "version": "^2.253.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -36,8 +36,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
     mavenArtifactId: "datadog-cdk-constructs",
   },
   peerDeps: [],
-  cdkVersion: "2.245.0",
-  cdkCliVersion: "^2.245.0",
+  cdkVersion: "2.253.0",
+  cdkCliVersion: "^2.253.0",
   deps: ["loglevel"],
   bundledDeps: ["loglevel"],
   devDeps: [

--- a/integration_tests/stacks/java/pom.xml
+++ b/integration_tests/stacks/java/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.241.0</cdk.version>
+        <cdk.version>2.253.0</cdk.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.245.0",
+    "aws-cdk-lib": "2.253.0",
     "constructs": "10.5.1",
     "esbuild": "^0.28.0",
     "eslint": "^9",
@@ -61,7 +61,7 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.245.0",
+    "aws-cdk-lib": "^2.253.0",
     "constructs": "^10.5.1"
   },
   "dependencies": {

--- a/src/datadog-lambda.ts
+++ b/src/datadog-lambda.ts
@@ -192,10 +192,11 @@ export class DatadogLambda extends Construct {
     // If any lambdas have already been added, override the commit sha and url
     if (this.lambdas) {
       this.lambdas.forEach((lambdaFunction: any) => {
-        if (lambdaFunction.environment[DD_TAGS] === undefined) {
+        const existingTags = lambdaFunction.environment.map.get(DD_TAGS);
+        if (existingTags === undefined) {
           return;
         }
-        const tags = lambdaFunction.environment[DD_TAGS].value.split(",");
+        const tags = existingTags.value.split(",");
         if (gitCommitSha) {
           const index = tags.findIndex((val: string) => val.split(":")[0] === "git.commit.sha");
           tags[index] = `git.commit.sha:${gitCommitSha}`;
@@ -206,7 +207,7 @@ export class DatadogLambda extends Construct {
           tags[index] = `git.repository_url:${gitRepoUrl}`;
         }
 
-        lambdaFunction.environment[DD_TAGS].value = tags.join(",");
+        lambdaFunction.addEnvironment(DD_TAGS, tags.join(","));
       });
     }
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -63,12 +63,10 @@ export function setGitEnvironmentVariables(
 
   // We're using an any type here because AWS does not expose the `environment` field in their type
   lambdas.forEach((lam) => {
-    if (lam.environment[DD_TAGS] !== undefined) {
-      lam.environment[DD_TAGS].value += `,git.commit.sha:${hash}`;
-    } else {
-      lam.addEnvironment(DD_TAGS, `git.commit.sha:${hash}`);
-    }
-    lam.environment[DD_TAGS].value += `,git.repository_url:${gitRepoUrl}`;
+    const tagsValue = `git.commit.sha:${hash},git.repository_url:${gitRepoUrl}`;
+    const existingTagValue = lam.environment.map.get(DD_TAGS)?.value;
+    const finalTagValue = existingTagValue ? `${existingTagValue},${tagsValue}` : tagsValue;
+    lam.addEnvironment(DD_TAGS, finalTagValue);
   });
 }
 
@@ -123,7 +121,7 @@ export function applyEnvVariables(lam: lambda.Function, baseProps: DatadogLambda
   log.debug(`Setting environment variables...`);
   const lam_with_env_vars: any = lam; //cast to any to access the private environment fields like in setGitEnvironmentVariables
   const setEnvIfUndefined = (envVar: string, value: string | boolean) => {
-    if (lam_with_env_vars.environment[envVar] === undefined) {
+    if (lam_with_env_vars.environment.map.get(envVar) === undefined) {
       lam.addEnvironment(envVar, value.toString().toLowerCase());
     }
   };

--- a/test/datadog-lambda.spec.ts
+++ b/test/datadog-lambda.spec.ts
@@ -854,10 +854,10 @@ describe("overrideGitMetadata", () => {
     });
     datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
     datadogLambda.addLambdaFunctions([hello], stack);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.repository_url:fake-url"]),
     );
   });
@@ -880,10 +880,10 @@ describe("overrideGitMetadata", () => {
     });
     datadogLambda.addLambdaFunctions([hello], stack);
     datadogLambda.overrideGitMetadata("fake-sha", "fake-url");
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.repository_url:fake-url"]),
     );
   });
@@ -913,10 +913,10 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.commit.sha:fake-sha"]),
       );
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.repository_url:fake-url"]),
       );
     });
@@ -949,10 +949,10 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining(["git.commit.sha:fake-sha"]),
       );
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(expect.arrayContaining(["testVar:xyz"]));
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(expect.arrayContaining(["testVar:xyz"]));
     });
   });
 
@@ -982,7 +982,7 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([goodbye], stack);
 
     [hello, goodbye].forEach((f) => {
-      expect((<any>f).environment[DD_TAGS].value.split(",")).toEqual(
+      expect((<any>f).environment.map.get(DD_TAGS).value.split(",")).toEqual(
         expect.arrayContaining([expect.stringContaining("git.commit.sha:fake-sha"), expect.stringMatching(REPO_REGEX)]),
       );
     });
@@ -1007,9 +1007,12 @@ describe("overrideGitMetadata", () => {
     datadogLambda.addLambdaFunctions([hello], stack);
 
     expect(
-      (<any>hello).environment[DD_TAGS].value.split(",").some((item: string) => item.includes("git.commit.sha")),
+      (<any>hello).environment.map
+        .get(DD_TAGS)
+        .value.split(",")
+        .some((item: string) => item.includes("git.commit.sha")),
     ).toEqual(true);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining([expect.stringMatching(REPO_REGEX)]),
     );
   });
@@ -1036,7 +1039,7 @@ describe("overrideGitMetadata", () => {
     });
 
     datadogLambda.addLambdaFunctions([hello], stack);
-    expect((<any>hello).environment[DD_TAGS].value.split(",")).toEqual(
+    expect((<any>hello).environment.map.get(DD_TAGS).value.split(",")).toEqual(
       expect.arrayContaining(["git.commit.sha:fake-sha"]),
     );
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,10 +5,10 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@aws-cdk/asset-awscli-v1@npm:2.2.263":
-  version: 2.2.263
-  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.263"
-  checksum: 10c0/d84d00fa1f576a7774a15f30431675fe174e2d42369117bf6b336c33b89525d61628364c084460029b23fa404b73474559af2274773e9e4f06be962f322690ff
+"@aws-cdk/asset-awscli-v1@npm:2.2.273":
+  version: 2.2.273
+  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.273"
+  checksum: 10c0/625f12bc6c659efcafdc135c0efcf0e780d4c33fbcbcf9cbcdef20b76d3cd7cfdf51c49306d7b65e37d58c6a4c1b20a15dac28a00bae55da10ccb01ade8a033b
   languageName: node
   linkType: hard
 
@@ -29,25 +29,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-api@npm:^2.2.0":
-  version: 2.2.2
-  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.2"
+"@aws-cdk/cloud-assembly-api@npm:^2.2.2":
+  version: 2.2.3
+  resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.3"
   dependencies:
     jsonschema: "npm:~1.4.1"
     semver: "npm:^7.7.4"
   peerDependencies:
-    "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
-  checksum: 10c0/cc5e7edd13d9d7e4ad7878c16f85a1a15c68e9ec51b71ad4a4c884ef0b3ed28fc25dc0627f0c226d65615cc6011ca02de94401862b650a996f8ccdff651e4d44
+    "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
+  checksum: 10c0/3f9309a28ef6e7ba62ed83925d8471b3141e991ec895f7b0340a5baa6a57cab1408e6876203cea2f8e6db75cf9785248e4015b4dca8c941b0c0ea2fc7900b8ea
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:^53.0.0":
-  version: 53.18.0
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:53.18.0"
+"@aws-cdk/cloud-assembly-schema@npm:^53.18.0":
+  version: 53.22.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:53.22.0"
   dependencies:
     jsonschema: "npm:~1.4.1"
     semver: "npm:^7.7.4"
-  checksum: 10c0/f8e2f7f7f603f6ef9e8ec1a5c87d9b24f0011995a08153b336deba9fb0cac5235a97c0846b84f960fef34631a1c48808e13fdfa623eceb798e062d8a60c8a39f
+  checksum: 10c0/cf7482b435e43b750d35195f6567ba8af1c2d75e54449cacf1a38ce0d7c7dfcae47e05c373e66d396fa8a278e03e797b8b495467c1f3e6dd763b235a96b0c0db
   languageName: node
   linkType: hard
 
@@ -2223,14 +2223,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:2.245.0":
-  version: 2.245.0
-  resolution: "aws-cdk-lib@npm:2.245.0"
+"aws-cdk-lib@npm:2.253.0":
+  version: 2.253.0
+  resolution: "aws-cdk-lib@npm:2.253.0"
   dependencies:
-    "@aws-cdk/asset-awscli-v1": "npm:2.2.263"
+    "@aws-cdk/asset-awscli-v1": "npm:2.2.273"
     "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.1"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.0"
-    "@aws-cdk/cloud-assembly-schema": "npm:^53.0.0"
+    "@aws-cdk/cloud-assembly-api": "npm:^2.2.2"
+    "@aws-cdk/cloud-assembly-schema": "npm:^53.18.0"
     "@balena/dockerignore": "npm:^1.0.2"
     case: "npm:1.6.3"
     fs-extra: "npm:^11.3.3"
@@ -2244,7 +2244,7 @@ __metadata:
     yaml: "npm:1.10.3"
   peerDependencies:
     constructs: ^10.5.0
-  checksum: 10c0/af558d5355524b977d363650aab2902ea7b5337319a181babc1ab10180c8c9e0f481f51661012c201f077bf1b21ac851c5396912a55baff9876ce370a4e53c1d
+  checksum: 10c0/dceca4b559c81aaf28a2cb2fd2581d61ee9e5555b31fba255ac2145db66e582c3e1a276d28ba8019cae334813e67e1676be91f07420877d01a6f76cb83a50176
   languageName: node
   linkType: hard
 
@@ -3022,7 +3022,7 @@ __metadata:
     "@types/node": "npm:^22"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
-    aws-cdk-lib: "npm:2.245.0"
+    aws-cdk-lib: "npm:2.253.0"
     constructs: "npm:10.5.1"
     esbuild: "npm:^0.28.0"
     eslint: "npm:^9"
@@ -3044,7 +3044,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:^6.0.3"
   peerDependencies:
-    aws-cdk-lib: ^2.245.0
+    aws-cdk-lib: ^2.253.0
     constructs: ^10.5.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
BREAKING CHANGE: Minimum aws-cdk-lib version is now ^2.253.0

<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

Resolves https://github.com/DataDog/datadog-cdk-constructs/issues/596

### Motivation

My CI is broken: [seek-oss/skuba/actions/runs/25618922361/job/75201906880](https://github.com/seek-oss/skuba/actions/runs/25618922361/job/75201906880)

### Testing Guidelines

I updated aws-cdk-lib to the latest version and ran yarn test.

### Additional Notes

This is the breaking change alternative to https://github.com/DataDog/datadog-cdk-constructs/pull/600

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [x] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
