### PR TITLE
fix: Changing Scope of Log Group Lookup in DataDogStepFunctions construct

### DIFF
--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -147,7 +147,7 @@ export class DatadogStepFunctions extends Construct {
         throw new Error(`logGroupArn is undefined. ${unsupportedCaseErrorMessage}`);
       }
 
-      logGroup = logs.LogGroup.fromLogGroupArn(this, "LogGroup", logGroupArn);
+      logGroup = logs.LogGroup.fromLogGroupArn(stateMachine, "LogGroup", logGroupArn);
     }
 
     // Configure state machine role to have permission to log to CloudWatch Logs, following


### PR DESCRIPTION
### What does this PR do?

fixes #666 

This updates the scope of the log group lookup in DatadogStepFunctions to be consistent with the scope of a newly-created log group in the same construct. Previously, newly-created log groups used the state machine as their scope while lookups used the DatadogStepFunctions construct itself.

### Motivation
My team encountered a synth error when using this construct with multiple statemachines that had predefined log groups because of a name collision in LogGroup constructs.

### Testing Guidelines
I verified that all existing unit tests passed. 

### Additional Notes
My assumption is that this was a miss in the original implementation of this construct, as I don't see any reason why the scopes would be different. While I can see the potential for this to be a breaking change, I also don't think anyone would've been able to use this construct with predefined log groups unless they only had exactly one statemachine in their stack. 

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
