### PR TITLE
chore: fix release script

### DIFF
--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -1,53 +1,111 @@
 #!/bin/bash
 
-RELEASE_VERSION=$1
+set -euo pipefail
+
+RELEASE_VERSION=${1:-}
+
+fail() {
+    echo "ERROR: $1" >&2
+    exit 1
+}
 
 echo "Attempting to create release version $RELEASE_VERSION"
 
-# Check that the release version exists and is properly formatted
-if [ -z $RELEASE_VERSION ]; then
-    echo "ERROR: You must specify a desired version number like"
-    echo "yarn create-release #.#.#"
-    exit 1
-elif [[ ! $RELEASE_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "ERROR: You must use a semantic version (e.g. 3.1.4)"
-    exit 1
+if [ -z "$RELEASE_VERSION" ]; then
+    fail "You must specify a desired version number like: yarn create-release #.#.#"
+elif [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "You must use a semantic version (e.g. 3.1.4)"
 fi
 
-# Make sure local tags are up to date before checking for an existing release.
+REPO_ROOT=$(git rev-parse --show-toplevel)
+VERSION_FILE="$REPO_ROOT/version.json"
+START_BRANCH=$(git branch --show-current)
+START_COMMIT=$(git rev-parse HEAD)
+RELEASE_TAG="v2-$RELEASE_VERSION"
+RELEASE_BRANCH="release-$RELEASE_TAG"
+
+[ "$START_BRANCH" = "main" ] || fail "Releases must be created from main."
+[ -z "$(git status --porcelain)" ] || fail "The working tree must be clean."
+
+# The previous release commit may be outside a shallow clone's history.
+if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+    git fetch --unshallow origin '+refs/heads/main:refs/remotes/origin/main' --quiet
+else
+    git fetch origin '+refs/heads/main:refs/remotes/origin/main' --quiet
+fi
 git fetch origin 'refs/tags/*:refs/tags/*' --quiet
 
-# Check that the release version has not already been published
-MATCHING_GITHUB_VERSION=$(git tag -l | grep $RELEASE_VERSION)
-if [ $MATCHING_GITHUB_VERSION ]; then
-    echo "ERROR: Version $MATCHING_GITHUB_VERSION already exists"
-    exit 1
+[ "$START_COMMIT" = "$(git rev-parse origin/main)" ] || fail "Local main must match origin/main."
+
+if git show-ref --verify --quiet "refs/tags/$RELEASE_TAG"; then
+    fail "Version $RELEASE_VERSION already exists."
+fi
+if git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+    fail "Local branch $RELEASE_BRANCH already exists."
+fi
+if [ -n "$(git ls-remote --heads origin "refs/heads/$RELEASE_BRANCH")" ]; then
+    fail "Remote branch $RELEASE_BRANCH already exists."
 fi
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-VERSION_FILE="$SCRIPT_DIR/../version.json"
-CURRENT_VERSION=$(jq -r '.version' "$VERSION_FILE")
-LAST_RELEASE_COMMIT=$(git log -1 --format=%H --fixed-strings --grep="Release v2-$CURRENT_VERSION" HEAD)
-if [ -z "$LAST_RELEASE_COMMIT" ]; then
-    echo "ERROR: Could not find the release commit for v2-$CURRENT_VERSION. Aborting."
-    exit 1
+CURRENT_VERSION=$(jq -er '.version | select(type == "string")' "$VERSION_FILE")
+PREVIOUS_TAG="v2-$CURRENT_VERSION"
+if ! PREVIOUS_RELEASE_COMMIT=$(git rev-parse --verify "refs/tags/$PREVIOUS_TAG^{commit}" 2>/dev/null); then
+    fail "Could not find previous release tag $PREVIOUS_TAG."
 fi
-jq --arg v "$RELEASE_VERSION" '.version = $v' "$VERSION_FILE" > "$VERSION_FILE.tmp" && mv "$VERSION_FILE.tmp" "$VERSION_FILE"
+PREVIOUS_RELEASE_BASE=$(git rev-parse "$PREVIOUS_RELEASE_COMMIT^")
+git merge-base --is-ancestor "$PREVIOUS_RELEASE_BASE" HEAD || fail "$PREVIOUS_TAG is not based on main."
 
-git add $VERSION_FILE
+# The tag's parent is the code shipped in the previous release. Exclude the
+# corresponding version-only commit merged into main from the next changelog.
+PREVIOUS_VERSION_COMMIT=$(git log -1 --format=%H -- "$VERSION_FILE")
+[ -n "$PREVIOUS_VERSION_COMMIT" ] || fail "Could not find the previous version commit."
+VERSION_AT_COMMIT=$(git show "$PREVIOUS_VERSION_COMMIT:version.json" | jq -er '.version | select(type == "string")')
+[ "$VERSION_AT_COMMIT" = "$CURRENT_VERSION" ] || fail "The previous version commit does not set version $CURRENT_VERSION."
 
-# Create a commit with all of the commit info for commits in this release
-INCLUDED_COMMITS=$(git log "$LAST_RELEASE_COMMIT"..HEAD --no-merges --oneline)
-git commit -m "chore: Release v2-$RELEASE_VERSION
+INCLUDED_COMMITS=$(
+    git log "$PREVIOUS_RELEASE_BASE"..HEAD --no-merges --format='%H%x09%h %s' |
+        awk -F '\t' -v excluded="$PREVIOUS_VERSION_COMMIT" '$1 != excluded { print $2 }'
+)
+
+CREATED_TAG=false
+PUSHED=false
+cleanup_release() {
+    status=$?
+    trap - EXIT
+    set +e
+    rm -f "$VERSION_FILE.tmp"
+    if [ "$(git branch --show-current)" = "$RELEASE_BRANCH" ]; then
+        git reset --hard "$START_COMMIT" >/dev/null 2>&1
+        git switch --quiet "$START_BRANCH" >/dev/null 2>&1
+    fi
+    if git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+        git branch -D "$RELEASE_BRANCH" >/dev/null 2>&1
+    fi
+    if [ "$CREATED_TAG" = "true" ] && [ "$PUSHED" = "false" ]; then
+        git tag -d "$RELEASE_TAG" >/dev/null 2>&1
+    fi
+    exit "$status"
+}
+trap cleanup_release EXIT
+
+git switch --quiet -c "$RELEASE_BRANCH"
+jq --arg v "$RELEASE_VERSION" '.version = $v' "$VERSION_FILE" > "$VERSION_FILE.tmp"
+mv "$VERSION_FILE.tmp" "$VERSION_FILE"
+git add "$VERSION_FILE"
+git commit -m "chore: Release $RELEASE_TAG
 
 This release includes the following commits:
-$(echo "$INCLUDED_COMMITS")
+$INCLUDED_COMMITS
 "
 
-# Tag it and push to a release branch
-git tag -m "Release v2-$RELEASE_VERSION" "v2-$RELEASE_VERSION"
-git push --atomic origin "$(git rev-parse --abbrev-ref HEAD):release-v2-$RELEASE_VERSION" v2-$RELEASE_VERSION
+git tag -m "Release $RELEASE_TAG" "$RELEASE_TAG"
+CREATED_TAG=true
+git push --atomic origin "$RELEASE_BRANCH" "$RELEASE_TAG"
+PUSHED=true
 
-# Log information to create a PR
-echo "Go to the following URL to create a PR for the release.  Please add a comprehensive description"
-echo "https://github.com/DataDog/datadog-cdk-constructs/compare/release-v2-$RELEASE_VERSION?expand=1"
+git switch --quiet "$START_BRANCH"
+git branch -D "$RELEASE_BRANCH" >/dev/null
+trap - EXIT
+
+echo "Go to the following URL to create a PR for the release. Please add a comprehensive description"
+echo "https://github.com/DataDog/datadog-cdk-constructs/compare/$RELEASE_BRANCH?expand=1"

--- a/scripts/create_release.sh
+++ b/scripts/create_release.sh
@@ -14,8 +14,7 @@ elif [[ ! $RELEASE_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     exit 1
 fi
 
-# Make sure local tags are up to date with the remote before anything else,
-# otherwise `git describe` below can fail and produce an empty commit list.
+# Make sure local tags are up to date before checking for an existing release.
 git fetch origin 'refs/tags/*:refs/tags/*' --quiet
 
 # Check that the release version has not already been published
@@ -25,20 +24,20 @@ if [ $MATCHING_GITHUB_VERSION ]; then
     exit 1
 fi
 
-LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
-if [ -z "$LAST_TAG" ]; then
-    echo "ERROR: Could not find a previous tag via git describe. Aborting."
-    exit 1
-fi
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 VERSION_FILE="$SCRIPT_DIR/../version.json"
+CURRENT_VERSION=$(jq -r '.version' "$VERSION_FILE")
+LAST_RELEASE_COMMIT=$(git log -1 --format=%H --fixed-strings --grep="Release v2-$CURRENT_VERSION" HEAD)
+if [ -z "$LAST_RELEASE_COMMIT" ]; then
+    echo "ERROR: Could not find the release commit for v2-$CURRENT_VERSION. Aborting."
+    exit 1
+fi
 jq --arg v "$RELEASE_VERSION" '.version = $v' "$VERSION_FILE" > "$VERSION_FILE.tmp" && mv "$VERSION_FILE.tmp" "$VERSION_FILE"
 
 git add $VERSION_FILE
 
 # Create a commit with all of the commit info for commits in this release
-INCLUDED_COMMITS=$(git log "$LAST_TAG"..HEAD --no-merges --oneline)
+INCLUDED_COMMITS=$(git log "$LAST_RELEASE_COMMIT"..HEAD --no-merges --oneline)
 git commit -m "chore: Release v2-$RELEASE_VERSION
 
 This release includes the following commits:
@@ -46,7 +45,7 @@ $(echo "$INCLUDED_COMMITS")
 "
 
 # Tag it and push to a release branch
-git tag "v2-$RELEASE_VERSION"
+git tag -m "Release v2-$RELEASE_VERSION" "v2-$RELEASE_VERSION"
 git push --atomic origin "$(git rev-parse --abbrev-ref HEAD):release-v2-$RELEASE_VERSION" v2-$RELEASE_VERSION
 
 # Log information to create a PR


### PR DESCRIPTION
### What does this PR do?

Makes release creation safe across shallow clones and squash-merged release branches.

- Uses the previous tag's parent as the shipped-code boundary and excludes the corresponding version-only commit on `main`.
- Fetches full `main` history when needed and requires a clean, synchronized `main` branch.
- Fails closed and restores local state when release creation fails.
- Creates the release on a temporary branch, leaving local `main` unchanged after a successful push.
- Prefills the annotated tag message.

### Motivation

`git describe` selected `v2-3.2.0` while creating `v2-5.0.0` because newer release tags point to squash-merged release branches. This added commits from several prior releases to the release notes. The script also left the release commit on local `main`, where branch protection prevented it from being pushed.

### Testing Guidelines

- Ran the script against a temporary Git remote from a depth-1 clone. The history included a non-ancestor release tag, a commit merged while the prior release PR was open, and a later commit message referencing the old release.
- Confirmed the script fetched full history, included both applicable commits, and excluded the prior version-only release commit.
- Confirmed the release branch, version, annotated tag message, and remote refs were correct without opening an editor.
- Confirmed successful release creation restored a clean, synchronized local `main` and removed the temporary local release branch.
- Forced a pre-commit failure and confirmed rollback removed all local and remote release refs and changes.
- Confirmed a dirty worktree and execution from another branch abort before mutation.

### Additional Notes

None.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
