### PR TITLE
fix: Changing Scope of Log Group Lookup in DatadogStepFunctions construct

### DIFF
--- a/src/datadog-step-functions.ts
+++ b/src/datadog-step-functions.ts
@@ -147,7 +147,7 @@ export class DatadogStepFunctions extends Construct {
         throw new Error(`logGroupArn is undefined. ${unsupportedCaseErrorMessage}`);
       }
 
-      logGroup = logs.LogGroup.fromLogGroupArn(this, "LogGroup", logGroupArn);
+      logGroup = logs.LogGroup.fromLogGroupArn(stateMachine, "LogGroup", logGroupArn);
     }
 
     // Configure state machine role to have permission to log to CloudWatch Logs, following

--- a/test/datadog-step-functions.spec.ts
+++ b/test/datadog-step-functions.spec.ts
@@ -42,6 +42,32 @@ describe("DatadogStepFunctions", () => {
       expect(logConfig.destinations).toHaveLength(1);
     });
 
+    it("supports multiple state machines with pre-existing, distinct log groups", () => {
+      const stack = new Stack();
+      const stateMachineOne = new sfn.StateMachine(stack, "StateMachineOne", {
+        definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, "PassStateOne")),
+        logs: {
+          destination: new logs.LogGroup(stack, "LogGroupOne"),
+          level: sfn.LogLevel.ERROR,
+          includeExecutionData: false,
+        },
+      });
+      const stateMachineTwo = new sfn.StateMachine(stack, "StateMachineTwo", {
+        definitionBody: sfn.DefinitionBody.fromChainable(new sfn.Pass(stack, "PassStateTwo")),
+        logs: {
+          destination: new logs.LogGroup(stack, "LogGroupTwo"),
+          level: sfn.LogLevel.ERROR,
+          includeExecutionData: false,
+        },
+      });
+
+      const datadogSfn = new DatadogStepFunctions(stack, "DatadogStepFunctions", {});
+      expect(() => {
+        datadogSfn.addStateMachines([stateMachineOne]);
+        datadogSfn.addStateMachines([stateMachineTwo]);
+      }).not.toThrow();
+    });
+
     it("throws if loggingConfiguration is an unresolved token", () => {
       const stack = new Stack();
       const stateMachine = new sfn.StateMachine(stack, "StateMachine", {


### PR DESCRIPTION
## What does this PR do?

Fixes #666.

This updates the scope of the log group lookup in `DatadogStepFunctions` to be consistent with the scope of a newly-created log group in the same construct. Previously, newly-created log groups used the state machine as their scope while lookups used the `DatadogStepFunctions` construct itself. This caused a construct-id collision ("There is already a Construct with name 'LogGroup' in DatadogStepFunctions.") when `addStateMachines` was called for more than one state machine that had a pre-defined log group.

Adds unit tests to #667, opened by @mjdean94, which contains the original one-line fix (`4066d28`/`eabe05c` after rebase). This PR keeps that fix commit as-is and adds a regression unit test on top, then runs it through this repo's full CI (including integration tests), which fork PRs cannot trigger since `tests.yml` only runs on `push`.

## Testing Guidelines

Added a unit test in `test/datadog-step-functions.spec.ts` that creates two state machines, each with its own pre-defined log group, and calls `addStateMachines` for each on the same `DatadogStepFunctions` construct. Verified locally that this test fails against the pre-fix scoping and passes with the fix.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog

Closes #667