### PR TITLE
chore: add node 26 runtime

### DIFF
--- a/src/layer-runtime-catalog.ts
+++ b/src/layer-runtime-catalog.ts
@@ -57,6 +57,11 @@ export const layerRuntimeCatalog = [
     layerNames: { x86_64: "Datadog-Node24-x", arm64: "Datadog-Node24-x" },
   },
   {
+    runtime: "nodejs26.x",
+    runtimeType: "NODE",
+    layerNames: { x86_64: "Datadog-Node26-x", arm64: "Datadog-Node26-x" },
+  },
+  {
     runtime: "python3.7",
     runtimeType: "PYTHON",
     layerNames: { x86_64: "Datadog-Python37", arm64: "Datadog-Python37-ARM" },


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-cdk-constructs/blob/main/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?
adds node26 support for recently released node26 lambda version
<!--- A brief description of the change being made with this pull request. --->

### Motivation

<!--- What inspired you to submit this pull request? --->

### Testing Guidelines

<!--- How did you test this pull request? --->

### Additional Notes

<!--- Anything else we should know when reviewing? --->

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
